### PR TITLE
Allow to load arbitrary models

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -481,8 +481,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         use_triton: bool = False,
         max_memory: Optional[dict] = None,
         device_map: Optional[str] = None,
-        quantize_config: BaseQuantizeConfig | None = None,
-        model_basename: str | None = None,
+        quantize_config: Optional[BaseQuantizeConfig] = None,
+        model_basename: Optional[str] = None,
         trust_remote_code: bool = False
     ):
         """load quantized model from local disk"""

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -481,7 +481,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         use_triton: bool = False,
         max_memory: Optional[dict] = None,
         device_map: Optional[str] = None,
-        quantize_config: BaseQuantizeConfig | None = None
+        quantize_config: BaseQuantizeConfig | None = None,
+        model_basename: str | None = None
     ):
         """load quantized model from local disk"""
         if use_triton:
@@ -497,7 +498,10 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         if quantize_config is None:
             quantize_config = BaseQuantizeConfig.from_pretrained(save_dir)
 
-        model_save_name = join(save_dir, f"gptq_model-{quantize_config.bits}bit")
+        if model_basename is None:
+            model_basename = f"gptq_model-{quantize_config.bits}bit"
+
+        model_save_name = join(save_dir, model_basename)
         if use_safetensors:
             model_save_name += ".safetensors"
         else:

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -56,7 +56,8 @@ class AutoGPTQForCausalLM:
         max_memory: Optional[dict] = None,
         device_map: Optional[str] = None,
         quantize_config: BaseQuantizeConfig | None = None,
-        model_basename: str | None = None
+        model_basename: str | None = None,
+        trust_remote_code: bool = False
     ) -> BaseGPTQForCausalLM:
         model_type = check_and_get_model_type(save_dir)
         return GPTQ_CAUSAL_LM_MODEL_MAP[model_type].from_quantized(
@@ -67,7 +68,8 @@ class AutoGPTQForCausalLM:
             max_memory=max_memory,
             device_map=device_map,
             quantize_config=quantize_config,
-            model_basename=model_basename
+            model_basename=model_basename,
+            trust_remote_code=trust_remote_code
         )
 
 

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -55,7 +55,8 @@ class AutoGPTQForCausalLM:
         use_triton: bool = False,
         max_memory: Optional[dict] = None,
         device_map: Optional[str] = None,
-        quantize_config: BaseQuantizeConfig | None = None
+        quantize_config: BaseQuantizeConfig | None = None,
+        model_basename: str | None = None
     ) -> BaseGPTQForCausalLM:
         model_type = check_and_get_model_type(save_dir)
         return GPTQ_CAUSAL_LM_MODEL_MAP[model_type].from_quantized(
@@ -65,7 +66,8 @@ class AutoGPTQForCausalLM:
             use_triton=use_triton,
             max_memory=max_memory,
             device_map=device_map,
-            quantize_config=quantize_config
+            quantize_config=quantize_config,
+            model_basename=model_basename
         )
 
 

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -54,7 +54,8 @@ class AutoGPTQForCausalLM:
         use_safetensors: bool = False,
         use_triton: bool = False,
         max_memory: Optional[dict] = None,
-        device_map: Optional[str] = None
+        device_map: Optional[str] = None,
+        quantize_config: BaseQuantizeConfig | None = None
     ) -> BaseGPTQForCausalLM:
         model_type = check_and_get_model_type(save_dir)
         return GPTQ_CAUSAL_LM_MODEL_MAP[model_type].from_quantized(
@@ -63,7 +64,8 @@ class AutoGPTQForCausalLM:
             use_safetensors=use_safetensors,
             use_triton=use_triton,
             max_memory=max_memory,
-            device_map=device_map
+            device_map=device_map,
+            quantize_config=quantize_config
         )
 
 

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -55,8 +55,8 @@ class AutoGPTQForCausalLM:
         use_triton: bool = False,
         max_memory: Optional[dict] = None,
         device_map: Optional[str] = None,
-        quantize_config: BaseQuantizeConfig | None = None,
-        model_basename: str | None = None,
+        quantize_config: Optional[BaseQuantizeConfig] = None,
+        model_basename: Optional[str] = None,
         trust_remote_code: bool = False
     ) -> BaseGPTQForCausalLM:
         model_type = check_and_get_model_type(save_dir)


### PR DESCRIPTION
`from_quantized()` has some hardcoded config that assumes a certain layout of files, e.g. `quantize_config.json` must be present and the model name must be `gptq_model-*`. All of it makes it impossible to load an arbitrary model, not created by AutoGPTQ itself (e.g. from HuggingFace Hub) without editing the model files.

This PR allows to specify custom `quantize_config`, `model_basename` and `trust_remote_code` params.

NOTES:
* There's a breaking change: `trust_remote_code` is now `False` by default. But I think it's better this way.
* I didn't add any docs.
* I didn't test this code with `*.index.json` files. Are they even supported here in the first place?
