### PR TITLE
Change save name

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -495,7 +495,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
         quantize_config = BaseQuantizeConfig.from_pretrained(save_dir)
 
-        model_save_name = join(save_dir, f"gptq_model-{self.quantize_config.bits}bit-{self.quantize_config.group_size}g")
+        model_save_name = join(save_dir, f"gptq_model-{quantize_config.bits}bit-{quantize_config.group_size}g")
         if use_safetensors:
             model_save_name += ".safetensors"
         else:

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -383,7 +383,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
         self.model.to(CPU)
 
-        model_save_name = f"gptq_model_{self.quantize_config.bits}bit_{self.quantize_config.group_size}g"
+        model_save_name = f"gptq_model-{self.quantize_config.bits}bit-{self.quantize_config.group_size}g"
         if use_safetensors:
             model_save_name += ".safetensors"
             state_dict = self.model.state_dict()
@@ -495,7 +495,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
         quantize_config = BaseQuantizeConfig.from_pretrained(save_dir)
 
-        model_save_name = join(save_dir, f"gptq_model_{self.quantize_config.bits}bit_{self.quantize_config.group_size}g")
+        model_save_name = join(save_dir, f"gptq_model-{self.quantize_config.bits}bit-{self.quantize_config.group_size}g")
         if use_safetensors:
             model_save_name += ".safetensors"
         else:

--- a/examples/quantization/basic_usage.py
+++ b/examples/quantization/basic_usage.py
@@ -5,7 +5,7 @@ from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
 
 
 pretrained_model_dir = "facebook/opt-125m"
-quantized_model_dir = "opt-125m-4bit"
+quantized_model_dir = "opt-125m_4bit_128g"
 
 # os.makedirs(quantized_model_dir, exist_ok=True)
 

--- a/examples/quantization/basic_usage.py
+++ b/examples/quantization/basic_usage.py
@@ -5,7 +5,7 @@ from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
 
 
 pretrained_model_dir = "facebook/opt-125m"
-quantized_model_dir = "opt-125m_4bit_128g"
+quantized_model_dir = "opt-125m-4bit-128g"
 
 # os.makedirs(quantized_model_dir, exist_ok=True)
 

--- a/examples/quantization/basic_usage_gpt_xl.py
+++ b/examples/quantization/basic_usage_gpt_xl.py
@@ -8,7 +8,7 @@ from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
 
 
 pretrained_model_dir = "gpt2-xl"
-quantized_model_dir = "gpt2-large-4bit"
+quantized_model_dir = "gpt2-large_4bit_128g"
 
 # os.makedirs(quantized_model_dir, exist_ok=True)
 def get_wikitext2(nsamples, seed, seqlen, tokenizer):

--- a/examples/quantization/basic_usage_gpt_xl.py
+++ b/examples/quantization/basic_usage_gpt_xl.py
@@ -8,7 +8,7 @@ from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
 
 
 pretrained_model_dir = "gpt2-xl"
-quantized_model_dir = "gpt2-large_4bit_128g"
+quantized_model_dir = "gpt2-large-4bit-128g"
 
 # os.makedirs(quantized_model_dir, exist_ok=True)
 def get_wikitext2(nsamples, seed, seqlen, tokenizer):

--- a/examples/quantization/basic_usage_wikitext2.py
+++ b/examples/quantization/basic_usage_wikitext2.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn as nn
 
 pretrained_model_dir = "facebook/opt-125m"
-quantized_model_dir = "opt-125m-4bit"
+quantized_model_dir = "opt-125m_4bit_128g"
 
 # os.makedirs(quantized_model_dir, exist_ok=True)
 def get_wikitext2(nsamples, seed, seqlen, model):

--- a/examples/quantization/basic_usage_wikitext2.py
+++ b/examples/quantization/basic_usage_wikitext2.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn as nn
 
 pretrained_model_dir = "facebook/opt-125m"
-quantized_model_dir = "opt-125m_4bit_128g"
+quantized_model_dir = "opt-125m-4bit-128g"
 
 # os.makedirs(quantized_model_dir, exist_ok=True)
 def get_wikitext2(nsamples, seed, seqlen, model):


### PR DESCRIPTION
Currently, BaseQuantizeConfig is arranged in alphabetical order. However, this is odd given the importance of groupsize.
Also, considering that there is no problem in loading a model with only groupsize and bit, it seems good to change bit and groupsize to be saved together as names.

ex) gptq_model-{bits}bits.pt -> gptq_model-{bits}bits-{groupsize}g.pt