### PR TITLE
Check that model_save_name exists before trying to load it, to avoid confusing checkpoint error

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -3,7 +3,7 @@ import json
 import os
 from dataclasses import dataclass, field, fields
 from logging import getLogger
-from os.path import join
+from os.path import join, isfile
 from typing import Dict, List, Optional, Union
 
 import accelerate
@@ -508,6 +508,9 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             model_save_name += ".safetensors"
         else:
             model_save_name += ".bin"
+
+        if not isfile(model_save_name):
+           raise FileNotFoundError(f"Could not find model at {model_save_name}")
 
         def skip(*args, **kwargs):
             pass


### PR DESCRIPTION
Very simple fix that checks that the model exists before trying to load it.

Without this, if the user passes the wrong folder/file name, they get this error:

```
ValueError: `checkpoint` should be the path to a file containing a whole state dict, or the index of a sharded checkpoint, or a folder containing a sharded checkpoint, but got /workspace/stable-vicuna-13B-GPTQ/stable-vicuna-13B-GPTQ-4bit1.latest.act-order.safetensors.
```

I found this quite confusing because it does not clearly indicate that the file was not found at all.

With this PR, the user will now get:
```
FileNotFoundError: Could not find model at /workspace/stable-vicuna-13B-GPTQ/stable-vicuna-13B-GPTQ-4bit1.latest.act-order.safetensors
```