### PR TITLE
[Bugfix] AutoTokenizer return list by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ quantized_model_dir = "opt-125m-4bit"
 tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir, use_fast=True)
 examples = [
     tokenizer(
-        "auto-gptq is an easy-to-use model quantization library with user-friendly apis, based on GPTQ algorithm."
+        "auto-gptq is an easy-to-use model quantization library with user-friendly apis, based on GPTQ algorithm.",
+        return_tensors="pt"
     )
 ]
 
@@ -147,7 +148,11 @@ Below is an example to evaluate `EleutherAI/gpt-j-6b` on sequence-classification
 from functools import partial
 
 import datasets
-from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+from transformers import Auto
+
+
+
+, AutoModelForCausalLM, GenerationConfig
 
 from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
 from auto_gptq.eval_tasks import SequenceClassificationTask


### PR DESCRIPTION
By runing the opt-125m exmaples, we got a issue 

```bash
│ /opt/conda/lib/python3.8/site-packages/auto_gptq/modeling/_base.py:149 in quantize               │
│                                                                                                  │
│   146 │   │   for example in examples:                                                           │
│   147 │   │   │   for k, v in example.items():                                                   │
│   148 │   │   │   │   print(k, v, len(v))                                                        │
│ ❱ 149 │   │   │   │   if len(v.shape) == 1:                                                      │
│   150 │   │   │   │   │   v = v.unsqueeze(0)                                                     │
│   151 │   │   │   │   example[k] = v.to(CUDA)                                                    │
│   152 │   │   │   try:                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'list' object has no attribute 'shape'
```

That was caused by:

```python
examples = [
    tokenizer(
        "auto-gptq is an easy-to-use model quantization library with user-friendly apis, based on GPTQ algorithm.")
]
```

which returns a {str: List} by default, by specific the return types of tensor, we can have a simple fix:

```python
examples = [
    tokenizer(
        "auto-gptq is an easy-to-use model quantization library with user-friendly apis, based on GPTQ algorithm."
    , return_tensors="pt")
]
```