### PR TITLE
Fix bug caused by 'groupsize' vs 'group_size' and change all code to use 'group_size' consistently

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -298,7 +298,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     logger.info(f'Quantizing {name} in layer {i + 1}/{len(layers)}...')
                     scale, zero, g_idx = gptq[name].fasterquant(
                         percdamp=self.quantize_config.damp_percent,
-                        groupsize=self.quantize_config.group_size,
+                        group_size=self.quantize_config.group_size,
                         actorder=self.quantize_config.desc_act
                     )
                     quantizers[f'{self.layers_block_name}.{i}.{name}'] = (

--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -82,7 +82,7 @@ def pack_model(
     model,
     quantizers,
     bits,
-    group_size,
+    groupsize,
     use_triton=False,
     use_cuda_fp16=True,
     desc_act=False,
@@ -103,7 +103,7 @@ def pack_model(
     logger.info('Packing model...')
     layers = find_layers(model)
     layers = {n: layers[n] for n in quantizers}
-    make_quant(model, quantizers, bits, group_size, use_triton=use_triton, use_cuda_fp16=use_cuda_fp16, desc_act=desc_act)
+    make_quant(model, quantizers, bits, groupsize, use_triton=use_triton, use_cuda_fp16=use_cuda_fp16, desc_act=desc_act)
     qlayers = find_layers(model, [QuantLinear])
     for name in qlayers:
         logger.info(name)

--- a/auto_gptq/modeling/llama.py
+++ b/auto_gptq/modeling/llama.py
@@ -130,7 +130,7 @@ class LlamaGPTQForCausalLM(BaseGPTQForCausalLM):
             model = accelerate.dispatch_model(model, device_map)
         
         if fused_attn:
-            make_quant_attn(model, use_triton=use_triton, groupsize = quantize_config.group_size, use_cuda_fp16=use_cuda_fp16, desc_act=quantize_config.desc_act,)
+            make_quant_attn(model, use_triton=use_triton, group_size = quantize_config.group_size, use_cuda_fp16=use_cuda_fp16, desc_act=quantize_config.desc_act,)
         if use_triton and fused_mlp:
             make_fused_mlp(model)
         model_config = model.config.to_dict()

--- a/auto_gptq/nn_modules/fused_attn.py
+++ b/auto_gptq/nn_modules/fused_attn.py
@@ -79,14 +79,14 @@ class QuantLlamaAttention(nn.Module):
 
         return attn_output, attn_weights, past_key_value
         
-def make_quant_attn(model, use_triton=False, groupsize=-1, use_cuda_fp16=True, desc_act=False):
+def make_quant_attn(model, use_triton=False, group_size=-1, use_cuda_fp16=True, desc_act=False):
     """
     Replace all LlamaAttention modules with QuantLlamaAttention modules, fusing the q, k, v projections.
     """
     if use_triton:
         from .qlinear_triton import QuantLinear
     else:
-        if not(desc_act) or groupsize == -1:
+        if not(desc_act) or group_size == -1:
             from .qlinear_old import QuantLinear
         else:
             from .qlinear import QuantLinear
@@ -104,10 +104,10 @@ def make_quant_attn(model, use_triton=False, groupsize=-1, use_cuda_fp16=True, d
         scales = torch.cat([q_proj.scales, k_proj.scales, v_proj.scales], dim=1)
         g_idx = torch.cat([q_proj.g_idx, k_proj.g_idx, v_proj.g_idx], dim=0)
         bias = torch.cat([q_proj.bias, k_proj.bias, v_proj.bias], dim=0) if q_proj.bias is not None else None
-        if (not(desc_act) or groupsize == -1) and not use_triton:
-            qkv_layer = QuantLinear(q_proj.bits, q_proj.groupsize, q_proj.infeatures, q_proj.outfeatures + k_proj.outfeatures + v_proj.outfeatures, True if q_proj.bias is not None else False, use_cuda_fp16 = use_cuda_fp16)
+        if (not(desc_act) or group_size == -1) and not use_triton:
+            qkv_layer = QuantLinear(q_proj.bits, q_proj.group_size, q_proj.infeatures, q_proj.outfeatures + k_proj.outfeatures + v_proj.outfeatures, True if q_proj.bias is not None else False, use_cuda_fp16 = use_cuda_fp16)
         else:
-            qkv_layer = QuantLinear(q_proj.bits, q_proj.groupsize, q_proj.infeatures, q_proj.outfeatures + k_proj.outfeatures + v_proj.outfeatures, True if q_proj.bias is not None else False)
+            qkv_layer = QuantLinear(q_proj.bits, q_proj.group_size, q_proj.infeatures, q_proj.outfeatures + k_proj.outfeatures + v_proj.outfeatures, True if q_proj.bias is not None else False)
         qkv_layer.qweight = qweights
         qkv_layer.qzeros = qzeros
         qkv_layer.scales = scales

--- a/auto_gptq/nn_modules/qlinear.py
+++ b/auto_gptq/nn_modules/qlinear.py
@@ -21,7 +21,7 @@ class QuantLinear(nn.Module):
     def __init__(
         self,
         bits,
-        groupsize,
+        group_size,
         infeatures,
         outfeatures,
         bias,
@@ -34,7 +34,7 @@ class QuantLinear(nn.Module):
         self.infeatures = infeatures
         self.outfeatures = outfeatures
         self.bits = bits
-        self.groupsize = groupsize if groupsize != -1 else infeatures
+        self.group_size = group_size if group_size != -1 else infeatures
         self.maxq = 2 ** self.bits - 1
 
         self.register_buffer(
@@ -43,15 +43,15 @@ class QuantLinear(nn.Module):
         )
         self.register_buffer(
             'qzeros',
-            torch.zeros((math.ceil(infeatures / self.groupsize), outfeatures // 32 * self.bits), dtype=torch.int32)
+            torch.zeros((math.ceil(infeatures / self.group_size), outfeatures // 32 * self.bits), dtype=torch.int32)
         )
         self.register_buffer(
             'scales',
-            torch.zeros((math.ceil(infeatures / self.groupsize), outfeatures), dtype=torch.float16)
+            torch.zeros((math.ceil(infeatures / self.group_size), outfeatures), dtype=torch.float16)
         )
         self.register_buffer(
             'g_idx',
-            torch.tensor([i // self.groupsize for i in range(infeatures)], dtype=torch.int32)
+            torch.tensor([i // self.group_size for i in range(infeatures)], dtype=torch.int32)
         )
         if bias:
             self.register_buffer('bias', torch.zeros((outfeatures), dtype=torch.float16))

--- a/auto_gptq/nn_modules/qlinear_triton.py
+++ b/auto_gptq/nn_modules/qlinear_triton.py
@@ -340,7 +340,7 @@ class QuantLinear(nn.Module):
     def __init__(
         self,
         bits,
-        groupsize,
+        group_size,
         infeatures,
         outfeatures,
         bias
@@ -353,7 +353,7 @@ class QuantLinear(nn.Module):
         self.infeatures = infeatures
         self.outfeatures = outfeatures
         self.bits = bits
-        self.groupsize = groupsize if groupsize != -1 else infeatures
+        self.group_size = group_size if group_size != -1 else infeatures
         self.maxq = 2 ** self.bits - 1
 
         self.register_buffer(
@@ -362,15 +362,15 @@ class QuantLinear(nn.Module):
         )
         self.register_buffer(
             'qzeros',
-            torch.zeros((math.ceil(infeatures / self.groupsize), outfeatures // 32 * self.bits), dtype=torch.int32)
+            torch.zeros((math.ceil(infeatures / self.group_size), outfeatures // 32 * self.bits), dtype=torch.int32)
         )
         self.register_buffer(
             'scales',
-            torch.zeros((math.ceil(infeatures / self.groupsize), outfeatures), dtype=torch.float16)
+            torch.zeros((math.ceil(infeatures / self.group_size), outfeatures), dtype=torch.float16)
         )
         self.register_buffer(
             'g_idx',
-            torch.tensor([i // self.groupsize for i in range(infeatures)], dtype=torch.int32)
+            torch.tensor([i // self.group_size for i in range(infeatures)], dtype=torch.int32)
         )
         if bias:
             self.register_buffer('bias', torch.zeros((outfeatures), dtype=torch.float16))


### PR DESCRIPTION
Today I found a bug in the quantisation code caused by this PR. in `auto_gptq/modeling/_utils.py` it uses 'groupsize' but code calling it passes `group_size`.

I fixed that, and then thought I should update the whole repo to be consistent. I think it would be great if one name was used consistently throughout the repo. This will help avoid bugs and confusion.  And 'group_size' seems to be the best name to use, as that's what's used in `quantize_config.json`.

With this PR merged into faster-llama, all `*.py` files use 'group_size' .  There are no longer any references to 'groupsize'.

**Before:**
```
tomj@Eddie ~/src/AutoGPTQ (faster-llama)$ find . -name "*.py" -exec grep -o "group_size" {} + | wc -l
      38
tomj@Eddie ~/src/AutoGPTQ (faster-llama)$ find . -name "*.py" -exec grep -o "groupsize" {} + | wc -l
      54
```

**After:**
```
tomj@Eddie ~/src/TheBloke_AutoGPTQ (TheBloke_faster-llama_groupsize_fix)$ find . -name "*.py" -exec grep -o "group_size" {} + | wc -l
      92
tomj@Eddie ~/src/TheBloke_AutoGPTQ (TheBloke_faster-llama_groupsize_fix)$ find . -name "*.py" -exec grep -o "groupsize" {} + | wc -l
       0
```

Note: I only changed .py files, not any CUDA kernels. I don't know CUDA code and don't want to risk touching anything which I don't understand, in case there any implications I don't know about.

I have done tests of Triton and CUDA inference, and Triton and CUDA quantisation, and all seems OK.

Hope this change is OK with you guys, @PanQiWei @qwopqwop200 ?