### PR TITLE
fix incorrect pack while using cuda, desc_act and grouping

### DIFF
--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -98,7 +98,7 @@ def pack_model(
     logger.info('Packing model...')
     layers = find_layers(model)
     layers = {n: layers[n] for n in quantizers}
-    make_quant(model, quantizers, bits, group_size, use_triton=use_triton)
+    make_quant(model, quantizers, bits, group_size, use_triton=use_triton, desc_act=desc_act)
     qlayers = find_layers(model, [QuantLinear])
     for name in qlayers:
         logger.info(name)


### PR DESCRIPTION
In `auto_gptq/modeling/_utils.py:pack_model`, argument `desc_act` is missing when calling `make_quant`. 
While using cuda, desc_act and grouping at the same time, `pack_model` and `make_quant` will have different implementation of `QuantLinear`, which results in empty `qlayers`.