### PR TITLE
Fix CUDA out of memory error in qlinear_old.py

### DIFF
--- a/auto_gptq/nn_modules/qlinear_old.py
+++ b/auto_gptq/nn_modules/qlinear_old.py
@@ -202,6 +202,7 @@ class QuantLinear(nn.Module):
                     autogptq_cuda.vecquant8matmul_old(x, self.qweight, out, self.scales.float(), self.qzeros, self.group_size)
                 else:
                     raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+            out = out.half()
         else:
             if self.wf.device != self.qzeros.device:
                self.wf = self.wf.to(self.qzeros.device)


### PR DESCRIPTION
Add a missing line from qlinear.py to qlinear_old.py to convert the output tensor.
This resolves a CUDA out of memory error that occurred without this line.