### PR TITLE
Perplexity calculation, exactly matching llama.cpp's method for easy comparisons

### DIFF
--- a/auto_gptq/eval_tasks/__init__.py
+++ b/auto_gptq/eval_tasks/__init__.py
@@ -1,3 +1,4 @@
 from .language_modeling_task import *
 from .sequence_classification_task import *
 from .text_summarization_task import *
+from .perplexity import Perplexity

--- a/auto_gptq/eval_tasks/perplexity.py
+++ b/auto_gptq/eval_tasks/perplexity.py
@@ -99,6 +99,8 @@ class Perplexity:
                 count += 1
 
             ppl = np.exp(nll / count)
+            #TODO: this results string gives the result of each batch, and duplicates llama.cpp's output
+            #      but currently nothing is being done with it - optionally return or print it?
             results += f'[{i+1}]{ppl:.4f}, '
             progress.set_description(f"Perplexity: {ppl:.4f}")
 

--- a/auto_gptq/eval_tasks/perplexity.py
+++ b/auto_gptq/eval_tasks/perplexity.py
@@ -1,0 +1,118 @@
+import torch
+import numpy as np
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from tqdm import tqdm
+from datasets import load_dataset
+from os.path import isfile
+
+class Perplexity:
+    def __init__(self, model, tokenizer=None, text=None, dataset='wikitext', device='cuda:0'):
+        #TODO: Detect if model is already instantiated, or is path to model_dir
+        if type(model) == str:
+            pass
+
+        #TODO: Properly handle multiple datasets, type checking, etc.
+        if text is None:
+            if type(dataset) == str:
+                if dataset == 'wikitext':
+                    # Special handling for wikitext, so that the output precisely matches
+                    # the text people are using with llama.cpp's perplexity
+                    # which is a raw file load of wikitext-v2-raw-v1/wiki.test.raw from ZIP at https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-raw-v1.zip?ref=salesforce-research
+                    wikidata = load_dataset('wikitext', 'wikitext-2-raw-v1', split='test')
+                    wikilist = [' \n' if s == '' else s for s in wikidata['text']]
+                    self._text = ''.join(wikilist)
+            else:
+                self._text = ''.join(dataset)
+        else:
+            self._text = text
+
+        self._model = model
+        self._tokenizer = tokenizer
+        self._device = device
+
+    @staticmethod
+    def softmax(logits):
+        e_x = np.exp(logits - np.max(logits))
+        return e_x / e_x.sum(axis=0)
+
+    def run(self, n_ctx, n_batch):
+        #TODO: Tokenising the dataset takes a couple of minutes, so might be nice to persist and reload tokenised result
+        #      this should be handled elsewhere, and be optional. Also needs hashing to confirm saved file is right
+        #      for the passed dataset.
+        saved_tokens = "/workspace/tokens.pth"
+        if not isfile(saved_tokens):
+            print("Tokenising")
+            tokens = self._tokenizer(self._text, truncation=False, return_tensors='pt').input_ids.to(self._device)
+            print("Saving tokens for later use")
+            torch.save(tokens, saved_tokens)
+        else:
+            tokens = torch.load(saved_tokens)
+
+        #TODO: could we tokenise in batches, to avoid having to do it all upfront?
+        #      but we need to know the length of the data tokens in order to know number of batches?
+        len_tokens = len(tokens[0])
+        print("Length of data:", len_tokens)
+        n_chunk = len_tokens // n_ctx
+
+        n_vocab = self._model.config.vocab_size
+
+        nll = 0.0
+        count = 0
+
+        # Algorithm duplicated from llama.cpp's perplexity so that results can be compared to the many ppl figures published already
+        # https://github.com/ggerganov/llama.cpp/blob/master/examples/perplexity/perplexity.cpp
+        print(f'Calculating perplexity over {n_chunk} chunks, batch_size={n_batch}')
+
+        progress = tqdm(range(n_chunk))
+        progress.set_description(f"Perplexity: - ")
+        results = ""
+        for i in progress:
+            start = i * n_ctx
+            end = start + n_ctx
+
+            num_batches = (n_ctx + n_batch - 1) // n_batch
+
+            logits = []
+
+            for j in range(num_batches):
+                batch_start = start + j * n_batch
+                batch_size  = min(end - batch_start, n_batch)
+
+                token_org = tokens[0][batch_start].item()
+
+                if j == 0:
+                    tokens[0][batch_start] = self._tokenizer.bos_token_id
+
+                with torch.no_grad():
+                    outputs = self._model(tokens[:, batch_start:batch_start+batch_size])
+                    batch_logits = outputs.logits
+
+                tokens[0][batch_start] = token_org
+
+                logits.append(batch_logits.detach())
+
+            for j in range(min(512, n_ctx // 2), n_ctx - 1):
+                tok_logits = logits[0][0][j].cpu().numpy()
+                prob = self.softmax(tok_logits)[tokens[0][start + j + 1]]
+
+                nll += -np.log(prob)
+                count += 1
+
+            ppl = np.exp(nll / count)
+            results += f'[{i+1}]{ppl:.4f}, '
+            progress.set_description(f"Perplexity: {ppl:.4f}")
+
+        print(f"Perplexity: {ppl:.4f}")
+        #print(results)
+
+#TODO: this is test code for the above class, to be cleaned up and removed from this file
+model_dir = "/workspace/models/huggyllama_llama-7b"
+tok = AutoTokenizer.from_pretrained(model_dir, use_fast=True)
+print("Loading model")
+mod = AutoModelForCausalLM.from_pretrained(model_dir, device_map='auto')
+
+ppl = Perplexity(mod, tok)
+
+n_ctx = 512
+n_batch = 512
+ppl.run(n_ctx, n_batch)


### PR DESCRIPTION
Hi guys

This is a first draft of a Perplexity class I'd like to add to AutoGPTQ for easy perplexity calculations of unquantised and GPTQ'd models.

I have exactly replicated the [perplexity algorithm that is used by llama.cpp's `perplexity` CLI tool](https://github.com/ggerganov/llama.cpp/blob/master/examples/perplexity/perplexity.cpp). I have confirmed that the perplexity scored generated is 100% identical to llama.cpp when tested on eg base Llama 7B unquantised.  (I've not tested other sizes or other models yet but plan to shortly).

I thought it would be useful to have an easy-to-run, simple ppl calculation in AutoGPTQ, and that it would be especially useful if these results could be directly compared to llama.cpp's perplexity scores.

There is a lot of data out there for PPL calculations with llama.cpp, eg in this lengthy llama.cpp discussion thread: https://github.com/ggerganov/llama.cpp/discussions/406. There are a lot of ppl scores for GGML models in 4bit, 5bit, 8bit and 16bi. And with this it will be possible to directly compare the quality of GPTQ quants to GGML quants.

This PR is just a draft at the moment, as I need to do some clean up and error checking, support various dataset types, add docs etc.  But the fundamental ppl calc works.

I'll keep working on this tomorrow.

Example output:
```
root@c33660202f0a:/workspace# python ppl.py
Loading model
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:16<00:00,  8.04s/it]
Found cached dataset wikitext (/root/.cache/huggingface/datasets/wikitext/wikitext-2-raw-v1/1.0.0/a241db52902eaf2c6aa732210bead40c090019a499ceb13bcbfa3f8ab646a126)
Tokenising
Token indices sequence length is longer than the specified maximum sequence length for this model (335688 > 2048). Running this sequence through the model will result in indexing errors
Saving tokens for later use
Length of data: 335688
Calculating perplexity over 655 chunks, batch_size=512
Perplexity: 5.9066: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 655/655 [04:53<00:00,  2.23it/s]
Perplexity: 5.9066
```

That was with Llama 7B, and as you can see it took just under 5 minutes to run. That was on an A6000 48GB, as quite a lot of VRAM is needed at the moment (more than 24GB to load fp16 7B).  I will see if I can lower VRAM requirements later.
