### PR TITLE
Forward position args to allow `model(tokens)` syntax

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -370,8 +370,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
     def to(self, device: Union[str, torch.device]):
         return self.model.to(device)
 
-    def forward(self, **kwargs):
-        return self.model(**kwargs)
+    def forward(self, *args, **kwargs):
+        return self.model(*args, **kwargs)
 
     def generate(self, **kwargs):
         """shortcut for model.generate"""


### PR DESCRIPTION
Fix for https://github.com/PanQiWei/AutoGPTQ/issues/81

Allows following code to work unaltered:

```
 outputs = self._model(tokens[:, batch_start:batch_start+batch_size]
```