### PR TITLE
Refactor fused MLP + fused attention loading. Fix for fused MLP requiring Triton even when not used.

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -487,7 +487,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
     @classmethod
     def get_fused_attention(cls):
-        logger.warning(f"{cls.__name__} doesn't support fused attention at this time. Fused Attention not injected..")
+        logger.warning(f"{cls.__name__} doesn't support fused attention at this time. Fused attention not injected.")
         return None
 
     @classmethod

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -1,4 +1,3 @@
-import abc
 import copy
 import json
 import os

--- a/auto_gptq/modeling/llama.py
+++ b/auto_gptq/modeling/llama.py
@@ -42,15 +42,14 @@ class LlamaGPTQForCausalLM(BaseGPTQForCausalLM):
 
     @classmethod
     def get_fused_attention_module(cls):
-        try:
-            if cls._fused_attention_module_type is None:
+        if cls._fused_attention_module_type is None:
+            try:
                 from ..nn_modules.fused_llama_attn import FusedLlamaAttentionForQuantizedModel
                 cls._fused_attention_module_type = FusedLlamaAttentionForQuantizedModel
-        except ImportError:
-            logger.error("Failed to import FusedLlamaAttentionForQuantizedModel")
-        except:
-            raise
-
+            except ImportError:
+                logger.error("Failed to import FusedLlamaAttentionForQuantizedModel")
+            except:
+                raise
         return cls._fused_attention_module_type
 
 __all__ = ["LlamaGPTQForCausalLM"]


### PR DESCRIPTION
This is a fix for: https://github.com/PanQiWei/AutoGPTQ/pull/43#issuecomment-1547925665

Changes:

1. In `modeling/_base.py`, add new classmethods `get_fused_attention_module` and `get_fused_mlp_module`. if called directly they return "this class does not support" warnings.
2. In `modeling/llama.py`, add same classmethods, implementing the imports of `FusedLlamaMLPForQuantizedModel` and `FusedLlamaAttentionForQuantizedModel` with try except blocks
3. In `modeling/_base.py` implement checks for `inject_fused_attention` and `inject_fused_mlp` which only call `get_fused_mlp_module` and `get_fused_attention_module` if right conditions are met.  In particular, don't call `get_fused_mlp_module` unless `use_triton` is True.
4. Therefore `FusedLlamaMLPForQuantizedModel` will not be imported unless the user specifies `use_triton` and `inject_fused_mlp`
5. Therefore the user does not need Triton installed and can execute CUDA code without errors.

Testing done:
1. Inference with: CUDA, CUDA + FA, Triton, Triton + FA, Triton + FM. Triton + FA + FM
2. Quantisation with CUDA