### PR TITLE
Minor syntax fix for auto.py

### DIFF
--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -21,7 +21,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "llama": LlamaGPTQForCausalLM,
     "opt": OPTGPTQForCausalLM,
     "moss": MOSSGPTQForCausalLM,
-    "gpt_bigcode": GPTBigCodeGPTQForCausalLM
+    "gpt_bigcode": GPTBigCodeGPTQForCausalLM,
     "codegen": CodeGenGPTQForCausalLM
 }
 


### PR DESCRIPTION
Minor syntax fix, error while running autogptq from latest branch:
```
  File "/workdir/venv/lib/python3.10/site-packages/auto_gptq/modeling/auto.py", line 25                                                                
    "codegen": CodeGenGPTQForCausalLM                                                                                                                  
    ^^^^^^^^^                                                                                                                                          
SyntaxError: invalid syntax
```