### PR TITLE
Pytorch qlinear

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -561,7 +561,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             raise FileNotFoundError(f"Could not find model at {model_save_name}")
 
         if not use_triton and trainable:
-            raise NotImplementedError("For now, trainable mode only supports triton backend.")
+            logger.warning("QuantLinear with cuda backend not support trainable mode yet, Switch to the pytorch backend.")
 
         # == step2: convert model to gptq-model (replace Linear with QuantLinear) == #
         def skip(*args, **kwargs):

--- a/auto_gptq/nn_modules/qlinear/qlinear_cuda.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_cuda.py
@@ -32,7 +32,8 @@ class QuantLinear(nn.Module):
         if bits not in [2, 3, 4, 8]:
             raise NotImplementedError("Only 2,3,4,8 bits are supported.")
         if trainable:
-            raise NotImplementedError("QuantLinear with cuda backend not support trainable mode yet.")
+            _autogptq_cuda_available = False
+            logger.warning("QuantLinear with cuda backend not support trainable mode yet, Switch to the pytorch backend.")
 
         self.infeatures = infeatures
         self.outfeatures = outfeatures

--- a/auto_gptq/nn_modules/qlinear/qlinear_cuda.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_cuda.py
@@ -33,7 +33,6 @@ class QuantLinear(nn.Module):
             raise NotImplementedError("Only 2,3,4,8 bits are supported.")
         if trainable:
             _autogptq_cuda_available = False
-            logger.warning("QuantLinear with cuda backend not support trainable mode yet, Switch to the pytorch backend.")
 
         self.infeatures = infeatures
         self.outfeatures = outfeatures

--- a/auto_gptq/nn_modules/qlinear/qlinear_cuda_old.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_cuda_old.py
@@ -34,7 +34,8 @@ class QuantLinear(nn.Module):
         if bits not in [2, 3, 4, 8]:
             raise NotImplementedError("Only 2,3,4,8 bits are supported.")
         if trainable:
-            raise NotImplementedError("QuantLinear with cuda backend not support trainable mode yet.")
+            _autogptq_cuda_available = False
+            logger.warning("QuantLinear with cuda backend not support trainable mode yet, Switch to the pytorch backend.")
         self.infeatures = infeatures
         self.outfeatures = outfeatures
         self.bits = bits

--- a/auto_gptq/nn_modules/qlinear/qlinear_cuda_old.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_cuda_old.py
@@ -35,7 +35,6 @@ class QuantLinear(nn.Module):
             raise NotImplementedError("Only 2,3,4,8 bits are supported.")
         if trainable:
             _autogptq_cuda_available = False
-            logger.warning("QuantLinear with cuda backend not support trainable mode yet, Switch to the pytorch backend.")
         self.infeatures = infeatures
         self.outfeatures = outfeatures
         self.bits = bits

--- a/auto_gptq/utils/peft_utils.py
+++ b/auto_gptq/utils/peft_utils.py
@@ -353,8 +353,6 @@ def get_gptq_peft_model(
     auto_find_all_linears: bool = True,
     train_mode: bool = False
 ):
-    if train_mode and not model.is_triton_backend:
-        raise NotImplementedError("currently only support triton backend when in train mode.")
     if train_mode and not model.trainable:
         model.enable_trainable_mode()
     if train_mode and not peft_config:


### PR DESCRIPTION
Changed to automatically switch to pytorch backend when trainable is enabled in cuda backend.
This trains at roughly 1.3x (70 minutes --> 90 minutes) slower pace than triton, but has the advantage of not using triton.