### PR TITLE
Fix and extend build_wheels.yml workflow

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -4,6 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build_wheels:
+    if: ${{ github.repository_owner == 'PanQiWei' }}
     name: Build wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -4,7 +4,6 @@ on: workflow_dispatch
 
 jobs:
   build_wheels:
-    if: ${{ github.repository_owner == 'PanQiWei' }}
     name: Build wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -4,7 +4,6 @@ on: workflow_dispatch
 
 jobs:
   build_wheels:
-    if: ${{ github.repository_owner == 'PanQiWei' }}
     name: Build wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -15,6 +14,8 @@ jobs:
     defaults:
       run:
         shell: pwsh
+    env:
+        CUDA_VERSION: ${{ matrix.cuda }}
 
     steps:
       - uses: actions/checkout@v3
@@ -38,27 +39,29 @@ jobs:
           auto-activate-base: false
 
       - name: Install Dependencies
-        env:
-          CUDA_VERSION: ${{ matrix.cuda }}
         run: |
           mamba install -y "pytorch[version=2.0.0,build=py*_cuda${env:CUDA_VERSION}*]" "pytorch-cuda=${env:CUDA_VERSION}" 'sentencepiece' 'cuda' 'ninja' -c 'pytorch' -c "nvidia/label/cuda-${env:CUDA_VERSION}.0" -c 'nvidia' -c 'conda-forge' -c 'defaults'
-          python -m pip install --upgrade setuptools wheel
+          python -m pip install --upgrade build setuptools wheel
 
       - name: Build Wheel
-        env:
-          CUDA_VERSION: ${{ matrix.cuda }}
         run: |
           $env:CUDA_PATH = $env:CONDA_PREFIX
           $env:CUDA_HOME = $env:CONDA_PREFIX
           if ($IsLinux) {$env:LD_LIBRARY_PATH = $env:CONDA_PREFIX + '/lib:' + $env:LD_LIBRARY_PATH}
           $env:TORCH_CUDA_ARCH_LIST = '3.5 3.7 5.0 5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX'
-          python setup.py sdist bdist_wheel
+          python -m build -n
 
       - uses: actions/upload-artifact@v3
         if: runner.os == 'Linux'
         with:
           name: 'linux-wheels'
           path: ./dist/*.whl
+
+      - uses: actions/upload-artifact@v3
+        if: runner.os == 'Linux'
+        with:
+          name: 'sdist'
+          path: ./dist/*.tar.gz
 
       - uses: actions/upload-artifact@v3
         if: runner.os == 'Windows'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -48,7 +48,8 @@ jobs:
           $env:CUDA_PATH = $env:CONDA_PREFIX
           $env:CUDA_HOME = $env:CONDA_PREFIX
           if ($IsLinux) {$env:LD_LIBRARY_PATH = $env:CONDA_PREFIX + '/lib:' + $env:LD_LIBRARY_PATH}
-          $env:TORCH_CUDA_ARCH_LIST = '3.5 3.7 5.0 5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX'
+          $env:TORCH_CUDA_ARCH_LIST = '6.0 6.1 7.0 7.5 8.0 8.6+PTX'
+          if ([decimal]$env:CUDA_VERSION -ge 11.8) { $env:TORCH_CUDA_ARCH_LIST = '6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX' }
           python -m build -n
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -59,13 +59,41 @@ jobs:
           path: ./dist/*.whl
 
       - uses: actions/upload-artifact@v3
-        if: runner.os == 'Linux'
+        if: runner.os == 'Windows'
+        with:
+          name: 'windows-wheels'
+          path: ./dist/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: 'main'
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade build setuptools wheel
+
+      - name: Build Wheel
+        run: |
+          python -m build -n
+
+      - uses: actions/upload-artifact@v3
         with:
           name: 'sdist'
           path: ./dist/*.tar.gz
 
       - uses: actions/upload-artifact@v3
-        if: runner.os == 'Windows'
         with:
-          name: 'windows-wheels'
+          name: 'no-cuda-wheel'
           path: ./dist/*.whl

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ try:
     TORCH_AVAILABLE = True
 except ImportError:
     TORCH_AVAILABLE = False
+    
 
 python_min_version = (3, 8, 0)
 python_min_version_str = '.'.join(map(str, python_min_version))
@@ -64,7 +65,7 @@ if TORCH_AVAILABLE:
     BUILD_CUDA_EXT = int(os.environ.get('BUILD_CUDA_EXT', '1')) == 1
     
     additional_setup_kwargs = dict()
-    if BUILD_CUDA_EXT and torch.cuda.is_available():
+    if BUILD_CUDA_EXT and (torch.cuda.is_available() or os.environ.get("GITHUB_ACTIONS", "false") == "true"):
         from torch.utils import cpp_extension
         from distutils.sysconfig import get_python_lib
         conda_cuda_include_dir=os.path.join(get_python_lib(),"nvidia/cuda_runtime/include")

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ try:
     TORCH_AVAILABLE = True
 except ImportError:
     TORCH_AVAILABLE = False
-    
 
 python_min_version = (3, 8, 0)
 python_min_version_str = '.'.join(map(str, python_min_version))


### PR DESCRIPTION
- Fixed compiling Cuda wheels. Required edit of `setup.py` to allow GitHub Actions to bypass `torch.cuda.is_available()`
- Added extended arch support for Cuda 11.8+
- Added uploading of sdist and non-Cuda wheel.

Successful test run here: https://github.com/jllllll/AutoGPTQ/actions/runs/5150921771