### PR TITLE
Specify UTF-8 encoding for README.md in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ common_setup_kwargs = {
     "name": "auto_gptq",
     "author": "PanQiWei",
     "description": "An easy-to-use LLMs quantization package with user-friendly apis, based on GPTQ algorithm.",
-    "long_description": (Path(__file__).parent / "README.md").read_text(),
+    "long_description": (Path(__file__).parent / "README.md").read_text(encoding="UTF-8"),
     "long_description_content_type": "text/markdown",
     "url": "https://github.com/PanQiWei/AutoGPTQ",
     "keywords": ["gptq", "quantization", "large-language-models", "pytorch", "transformers"],


### PR DESCRIPTION
This PR adds an explicit UTF-8 encoding argument to the `read_text` call when reading README.md in setup.py. Without specifying the encoding, it defaults to the system encoding, which can cause issues on Windows systems where UTF-8 is not the norm. Some codepages will raise a UnicodeDecodeError due to the exotic characters (e.g., emojis) present in the README.md file.