### PR TITLE
Fix error message

### DIFF
--- a/auto_gptq/nn_modules/qlinear/qlinear_triton.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_triton.py
@@ -34,7 +34,7 @@ class QuantLinear(nn.Module, TritonModuleMixin):
         if bits not in [2, 4, 8]:
             raise NotImplementedError("Only 2,4,8 bits are supported.")
         if infeatures % 32 != 0 or outfeatures % 32 != 0:
-            raise NotImplementedError("in_feature or out_feature must be divisible by 32.")
+            raise NotImplementedError("in_feature and out_feature must be divisible by 32.")
         self.infeatures = infeatures
         self.outfeatures = outfeatures
         self.bits = bits


### PR DESCRIPTION
Stumbled upon this on an earlier version trying to Quantize a Falcon-7b (no success so far)
This model has non 256 multiples of features and was triggering this error.

However, the label of the error did not match the test.
Both in_feature and out_feature need to be divisible to fullfill the test abvoe.