### PR TITLE
[FEATURE] Implement perplexity metric to compare against llama.cpp

### DIFF
--- a/auto_gptq/utils/__init__.py
+++ b/auto_gptq/utils/__init__.py
@@ -1,0 +1,1 @@
+from .perplexity_utils import Perplexity

--- a/auto_gptq/utils/perplexity_utils.py
+++ b/auto_gptq/utils/perplexity_utils.py
@@ -1,0 +1,231 @@
+import sys
+import torch
+import numpy as np
+from tqdm import tqdm
+from datasets import load_dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+class Perplexity:
+    """
+    A class for calculating the perplexity of a language model.
+    """
+
+    def __init__(self, model, tokenizer=None, device='auto', dataset_path='wikitext', 
+                 dataset_name=None, split='test', text_column='text'):
+        """
+        Calculate perplexity using the same method as seen in llama.cpp.
+
+        Parameters
+        ----------
+        model : AutoModelForCausalLM or str
+            The language model for which the perplexity is calculated.
+        tokenizer : AutoTokenizer or str
+            The tokenizer corresponding to the model.
+        device : str, optional
+            The device to run the calculations on. If auto, the device that your model uses
+            will be the device used for these calculations. Default is 'auto'.
+        dataset_path : str, optional
+            The path to the dataset on the Hugging Face dataset hub. Default is 'wikitext'.
+        dataset_name : str, optional
+            The name of the dataset. Default is None.
+        split : str, optional
+            The split of the dataset to use. Default is 'test'.
+        text_column : str, optional
+            The name of the column in the dataset that contains the text data. Default is 'text'.
+        """
+
+        if tokenizer is None and type(model) == str:
+            tokenizer = AutoTokenizer.from_pretrained(model)
+        
+        elif type(tokenizer) == str:
+            tokenizer = AutoTokenizer.from_pretrained(tokenizer)
+        
+        elif tokenizer is None and type(model) != str:
+            raise Exception('Tokenizer cannot be None if model is not a str. Please load a tokenizer first:\n' +
+                            'tokenizer = AutoTokenizer.from_pretrained(model_name)')
+
+        if type(model) == str:
+            model = AutoModelForCausalLM.from_pretrained(model)
+
+        self._device = self._get_device() if device == 'auto' else device
+        self._model = model.to(self._device)
+
+        self._tokenizer = tokenizer
+        self._dataset_path = dataset_path
+        self._dataset_name = dataset_name
+        self._split = split
+        self._text_column = text_column
+        self._text = self._prepare_data()
+    
+    def _get_device(self):
+        if torch.backends.mps.is_available():
+            return 'mps'
+        elif torch.cuda.is_available():
+            return 'cuda:0'
+        else:
+            return 'cpu'
+    
+    def _prepare_data(self):
+        """
+        Prepares the dataset by loading and formatting.
+
+        Returns
+        -------
+        str
+            The formatted dataset as a single string.
+        """
+        if self._dataset_path == 'wikitext':
+            self._dataset_name = 'wikitext-2-raw-v1'
+        
+        # Load the dataset
+        data = load_dataset(self._dataset_path, self._dataset_name, split=self._split)
+        # Format the text column of the dataset
+        text_list = [' \n' if s == '' else s for s in data[self._text_column]]
+        return ''.join(text_list)
+
+    @staticmethod
+    def softmax(logits):
+        """
+        Static method for applying the softmax function.
+
+        Parameters
+        ----------
+        logits : np.ndarray
+            The input to the softmax function.
+
+        Returns
+        -------
+        np.ndarray
+            The output of the softmax function.
+        """
+        e_x = np.exp(logits - np.max(logits))
+        return e_x / e_x.sum(axis=0)
+
+    def calculate_perplexity(self, n_ctx=512, n_batch=512):
+        """
+        Calculates the perplexity of the language model.
+
+        Parameters
+        ----------
+        n_ctx : int
+            The context size.
+        n_batch : int
+            The batch size.
+        
+        Returns
+        -------
+        list
+            The list of perplexity scores calculated.
+        """
+        # Tokenize the text
+        self._tokenizer.model_max_length = sys.maxsize
+        tokens = self._tokenizer(self._text, truncation=False, return_tensors='pt').input_ids.to(self._device)
+
+        nll = 0.0  # Negative log likelihood
+        count = 0  # Counter for processed tokens
+        curr_ppl = 0
+        all_perplexity = []
+
+        with tqdm(range(len(tokens[0]) // n_ctx), desc="Perplexity: - ") as progress:
+            for i in progress:
+                # Process each batch of tokens
+                nll, count = self._process_batch(i, n_ctx, n_batch, tokens, nll, count)
+
+                # Calculate and display the current perplexity
+                curr_ppl = np.exp(nll / count)
+                all_perplexity.append(curr_ppl)
+                progress.set_description(f"Perplexity: {curr_ppl:.4f}")
+
+        return all_perplexity
+
+    def _process_batch(self, i, n_ctx, n_batch, tokens, nll, count):
+        """
+        Processes each batch of tokens.
+
+        Parameters
+        ----------
+        i : int
+            The batch index.
+        n_ctx : int
+            The context size.
+        n_batch : int
+            The batch size.
+        tokens : torch.Tensor
+            The tokenized text.
+        nll : float
+            The current negative log likelihood.
+        count : int
+            The current count of processed tokens.
+
+        Returns
+        -------
+        float
+            The updated negative log likelihood.
+        int
+            The updated count of processed tokens.
+        """
+        start = i * n_ctx
+        end = start + n_ctx
+
+        num_batches = (n_ctx + n_batch - 1) // n_batch
+
+        logits = []
+
+        for j in range(num_batches):
+            batch_start = start + j * n_batch
+            batch_size  = min(end - batch_start, n_batch)
+
+            token_org = tokens[0][batch_start].item()
+
+            if j == 0:
+                # Replace the first token with the BOS token
+                tokens[0][batch_start] = self._tokenizer.bos_token_id
+
+            # Compute the logits for the current batch of tokens
+            batch_logits = self._compute_batch_logits(tokens, batch_start, batch_size)
+
+            tokens[0][batch_start] = token_org
+
+            logits.append(batch_logits)
+        
+        # We rely on the fact that attention in the forward pass only looks at previous
+        # tokens here, so the logits returned for each token are an accurate representation
+        # of what the model would have predicted at that point.
+        # 
+        # Example, we have a context window of 512, we will compute perplexity for each of the
+        # last 256 tokens.  Then, we split the input up into context window size chunks to
+        # process the entire prompt.
+
+        for j in range(min(512, n_ctx // 2), n_ctx - 1):
+            tok_logits = logits[0][0][j].cpu().numpy()
+            # Compute the probability of the next token
+            prob = self.softmax(tok_logits)[tokens[0][start + j + 1]]
+
+            # Update the negative log likelihood and the count of processed tokens
+            nll += -np.log(prob, where=prob>0)
+            count += 1
+
+        return nll, count
+
+    def _compute_batch_logits(self, tokens, batch_start, batch_size):
+        """
+        Computes the logits for a batch of tokens.
+
+        Parameters
+        ----------
+        tokens : torch.Tensor
+            The tokenized text.
+        batch_start : int
+            The start index of the batch.
+        batch_size : int
+            The size of the batch.
+
+        Returns
+        -------
+        torch.Tensor
+            The logits for the batch of tokens.
+        """
+        # Compute the logits without keeping track of gradients
+        with torch.no_grad():
+            outputs = self._model(tokens[:, batch_start:batch_start+batch_size])
+        return outputs.logits.detach()

--- a/examples/benchmark/perplexity.py
+++ b/examples/benchmark/perplexity.py
@@ -43,8 +43,7 @@ if __name__ == "__main__":
             args.model_name,
             model_basename=args.model_basename,
             use_safetensors=True,
-            trust_remote_code=True,
-            device=args.device
+            trust_remote_code=True
         )
     else:
         from transformers import AutoTokenizer, AutoModelForCausalLM

--- a/examples/benchmark/perplexity.py
+++ b/examples/benchmark/perplexity.py
@@ -1,0 +1,56 @@
+import os
+import argparse
+from auto_gptq.utils import Perplexity
+
+if __name__ == "__main__":
+    """
+    Example usage.
+
+    Default usage with GPT2 model:
+    python examples/benchmark/perplexity.py
+
+    Specify GPTQ quantized model:
+    python examples/benchmark/perplexity.py \
+        --model_name TheBloke/open-llama-7b-open-instruct-GPTQ \
+        --model_basename gptq_model-4bit-128g \
+        --is_quantized
+    
+    Change your dataset:
+    python examples/benchmark/perplexity.py --dataset_path tiny_shakespeare
+
+    """
+    parser = argparse.ArgumentParser(description="Calculate Perplexity for a model.")
+    parser.add_argument("--model_name", type=str, default='gpt2', help="Model name.")
+    parser.add_argument("--model_basename", type=str, default=None, help="Model file's basename.")
+    parser.add_argument("--n_ctx", type=int, default=512, help="Context size.")
+    parser.add_argument("--n_batch", type=int, default=512, help="Batch size.")
+    parser.add_argument("--device", type=str, default="auto", help="Device to use.")
+    parser.add_argument("--dataset_path", type=str, default='wikitext', help="Path to the dataset.")
+    parser.add_argument("--dataset_name", type=str, default=None, help="Name of the dataset.")
+    parser.add_argument("--split", type=str, default='test', help="Dataset split to use.")
+    parser.add_argument("--text_column", type=str, default='text', help="Column in the dataset containing the text.")
+    parser.add_argument("--is_quantized", action=argparse.BooleanOptionalAction, default=False, help="Is the model GPTQ quantized?")
+    args = parser.parse_args()
+
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+    if args.is_quantized:
+        from transformers import AutoTokenizer
+        from auto_gptq import AutoGPTQForCausalLM
+
+        tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+        model = AutoGPTQForCausalLM.from_quantized(
+            args.model_name,
+            model_basename=args.model_basename,
+            use_safetensors=True,
+            trust_remote_code=True,
+            device=args.device
+        )
+    else:
+        from transformers import AutoTokenizer, AutoModelForCausalLM
+
+        tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+        model = AutoModelForCausalLM.from_pretrained(args.model_name)
+
+    ppl = Perplexity(model, tokenizer, args.device, args.dataset_path, args.dataset_name, args.split, args.text_column)
+    ppl.calculate_perplexity(args.n_ctx, args.n_batch)


### PR DESCRIPTION
Perplexity: *Intuitively, it can be thought of as an evaluation of the model’s ability to predict uniformly among the set of specified tokens in a corpus.* We leverage @TheBloke's replication of llama.cpp perplexity in #70 and build a functioning class that is flexible to calculate perplexity on the standard `wikitext` dataset.

For example, GPT2 scores `27.2268` on wikitext and `49.7432` on Shakespeare, meanwhile the GPTQ open-llama 7B scores `8.3029` in perplexity.

## API

It has been implemented in utils because when you install AutoGPTQ, you can easily import it to check perplexity against any of your GPTQ models. 

The very basic API will automatically load your transformer onto the most powerful device on your machine and calculate perplexity:

```python
from auto_gptq.utils import Perplexity

ppl = Perplexity('gpt2')
ppl.calculate_perplexity()
```

## Examples

Additionally, I provide a couple of examples in `examples/benchmark/perplexity` along with a CLI for ease of use.

I have tested this against GPT2 mainly. The basic example is below which will run GPT2:

```
python examples/benchmark/perplexity.py
```

You can also use AutoGPTQ quantized models:

```
python examples/benchmark/perplexity.py \
    --model_name TheBloke/open-llama-7b-open-instruct-GPTQ \
    --model_basename gptq_model-4bit-128g \
    --is_quantized
```

## Further testing

Although I have been able to implement this class, I do not have the resources to run against the unquantized version of larger models like Llama 7B. I would appreciate it if @TheBloke or someone else could benchmark huggyllama once again, just so we can confirm that calculations are the same as in llama.cpp.

The command should be:

```
python examples/benchmark/perplexity.py --model_name huggyllama/llama-7b
```