### PR TITLE
Change the install script so it attempts to build the CUDA extension in all cases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,17 +10,18 @@ try:
 except ImportError:
     TORCH_AVAILABLE = False
 
-IN_GITHUB_ACTIONS = os.environ.get("GITHUB_ACTIONS", "false") == "true"
-
 python_min_version = (3, 8, 0)
 python_min_version_str = '.'.join(map(str, python_min_version))
 if sys.version_info < python_min_version:
     print(f"You are using Python {platform.python_version()}. Python >={python_min_version_str} is required.")
     sys.exit(-1)
 
-CUDA_VERSION = "".join(os.environ.get("CUDA_VERSION", "").split("."))
+if TORCH_AVAILABLE:
+    CUDA_VERSION = "".join(torch.cuda.version).split(".")
+else:
+    CUDA_VERSION = "".join(os.environ.get("CUDA_VERSION", "").split("."))
 
-version = "0.3.0" + (f"+cu{CUDA_VERSION}" if CUDA_VERSION and IN_GITHUB_ACTIONS else "")
+version = "0.3.0" + (f"+cu{CUDA_VERSION}" if CUDA_VERSION else "")
 common_setup_kwargs = {
     "version": version,
     "name": "auto_gptq",
@@ -52,7 +53,7 @@ requirements = [
     "rouge",
     "torch>=1.13.0",
     "safetensors",
-    "transformers>=4.29.0",
+    "transformers>=4.31.0",
     "peft"
 ]
 
@@ -66,7 +67,7 @@ if TORCH_AVAILABLE:
     BUILD_CUDA_EXT = int(os.environ.get('BUILD_CUDA_EXT', '1')) == 1
     
     additional_setup_kwargs = dict()
-    if BUILD_CUDA_EXT and (torch.cuda.is_available() or IN_GITHUB_ACTIONS):
+    if BUILD_CUDA_EXT:
         from torch.utils import cpp_extension
         from distutils.sysconfig import get_python_lib
         conda_cuda_include_dir = os.path.join(get_python_lib(), "nvidia/cuda_runtime/include")

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if sys.version_info < python_min_version:
     sys.exit(-1)
 
 if TORCH_AVAILABLE:
-    CUDA_VERSION = "".join(torch.version.cuda).split(".")
+    CUDA_VERSION = "".join(torch.version.cuda.split("."))
 else:
     CUDA_VERSION = "".join(os.environ.get("CUDA_VERSION", "").split("."))
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if sys.version_info < python_min_version:
     sys.exit(-1)
 
 if TORCH_AVAILABLE:
-    CUDA_VERSION = "".join(torch.cuda.version).split(".")
+    CUDA_VERSION = "".join(torch.version.cuda).split(".")
 else:
     CUDA_VERSION = "".join(os.environ.get("CUDA_VERSION", "").split("."))
 


### PR DESCRIPTION
CUDA extension is now always built, which is required since 0.3.0 because without the CUDA extension, code will throw an error about not being able to load `autogptq_cuda_256`.

Therefore `GITHUB_ACTIONS=true` is no longer needed or used.

The new code also attempts to get the CUDA version from Torch, so that it can always be added to the version number when found, as in:
```
auto-gptq-0.3.0+cu118
```
(previously this +cuXXX was only added in GITHUB_ACTIONS)

I believe this will solve most or all of the installation problems people are having, where the CUDA extension is not installed.

If a user does NOT want the extension to build, they can still pass `BUILD_CUDA_EXT=0` as before.  However currently that will cause AutoGPTQ to fail to work (due to the error about not being able to find `autogptq_cuda_256`) so I think right now there is no point to doing that.

I have tested the new install script on a system that previously failed to build automatically, and also in a Docker container, and both worked fine.


I also bumped Transformers version to 4.31.0 for Llama 2 compatibility.