### PR TITLE
Add Safetensors metadata saving, with some values saved to each .safetensor file

### DIFF
--- a/auto_gptq/__init__.py
+++ b/auto_gptq/__init__.py
@@ -1,3 +1,4 @@
+__version__ = "0.3.1"
 from .modeling import BaseQuantizeConfig
 from .modeling import AutoGPTQForCausalLM
 from .utils.peft_utils import get_gptq_peft_model

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -530,6 +530,24 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 safetensors_metadata = {}
             elif not isinstance(safetensors_metadata, dict):
                 raise TypeError("safetensors_metadata must be a dictionary.")
+            else:
+                logger.debug(f"Received safetensors_metadata: {safetensors_metadata}")
+                new_safetensors_metadata = {}
+                converted_keys = False
+                for key, value in safetensors_metadata.items():
+                    if not isinstance(key, str) or not isinstance(value, str):
+                        converted_keys = True
+                        try:
+                            new_key = str(key)
+                            new_value = str(value)
+                        except Exception as e:
+                            raise TypeError(f"safetensors_metadata: both keys and values must be strings and an error occured when trying to convert them: {e}")
+                        if new_key in new_safetensors_metadata:
+                            logger.warning(f"After converting safetensors_metadata keys to strings, the key '{new_key}' is duplicated. Ensure that all your metadata keys are strings to avoid overwriting.")
+                        new_safetensors_metadata[new_key] = new_value
+                safetensors_metadata = new_safetensors_metadata
+                if converted_keys:
+                    logger.debug(f"One or more safetensors_metadata keys or values had to be converted to str(). Final safetensors_metadata: {safetensors_metadata}")
 
             # Format is required to enable Accelerate to load the metadata
             # otherwise it raises an OSError

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -446,6 +446,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         repo_id: str,
         save_dir: Optional[str] = None,
         use_safetensors: Optional[bool] = True,
+        safetensors_metadata: Optional[Dict[str, str]] = None,
         commit_message: Optional[str] = "Upload of AutoGPTQ quantized model",
         use_auth_token: Optional[Union[bool, str]] = None,
         private: Optional[bool] = None,
@@ -465,6 +466,10 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             use_safetensors (`bool`, *optional*):
                 Save the model using `safetensors`.
                 If the model has already been saved, this parameter can be omitted.
+            safetensors_metadata: (`dict`, *optional*, defaults to `None`):
+                Pass optional metadata dictionary to be saved in the `safetensors` model file(s).
+                Metadata is optional and is purely for informational purposes. It does not affect inference.
+                If `None`, no metadata will be saved.
             commit_message (`str`, *optional*, defaults to `"Upload tool"`):
                 Message to commit while pushing.
             use_auth_token (`bool` or `str`, *optional*):
@@ -484,7 +489,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         
         if save_dir is not None:
             logger.info(f"Saving model to {save_dir}")
-            self.save_quantized(save_dir, use_safetensors)
+            self.save_quantized(save_dir, use_safetensors, safetensors_metadata)
 
         repo_url = create_repo(
             repo_id=repo_id, token=token, private=private, exist_ok=True, repo_type="model"
@@ -507,7 +512,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 repo_type="model",
             )
 
-    def save_quantized(self, save_dir: str, use_safetensors: bool = False):
+    def save_quantized(self, save_dir: str, use_safetensors: bool = False, safetensors_metadata: Optional[Dict[str, str]] = None):
         """save quantized model and configs to local disk"""
         os.makedirs(save_dir, exist_ok=True)
 
@@ -521,7 +526,21 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             model_save_name = model_base_name + ".safetensors"
             state_dict = self.model.state_dict()
             state_dict = {k: v.clone().contiguous() for k, v in state_dict.items()}
-            safe_save(state_dict, join(save_dir, model_save_name))
+            if safetensors_metadata is None:
+                safetensors_metadata = {}
+            elif not isinstance(safetensors_metadata, dict):
+                raise TypeError("safetensors_metadata must be a dictionary.")
+
+            # Format is required to enable Accelerate to load the metadata
+            # otherwise it raises an OSError
+            safetensors_metadata['format'] = "pt"
+            # Store the quantization configuration as safetensors metadata
+            safetensors_metadata['gptq_bits'] = str(self.quantize_config.bits)
+            safetensors_metadata['gptq_group_size'] = str(self.quantize_config.group_size)
+            safetensors_metadata['gptq_desc_act'] = str(self.quantize_config.desc_act)
+            safetensors_metadata['gptq_damp_percent'] = str(self.quantize_config.damp_percent)
+
+            safe_save(state_dict, join(save_dir, model_save_name), safetensors_metadata)
         else:
             model_save_name = model_base_name + ".bin"
             torch.save(self.model.state_dict(), join(save_dir, model_save_name))
@@ -531,10 +550,10 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         self.quantize_config.model_name_or_path = save_dir
         self.quantize_config.model_file_base_name = model_base_name
 
-    def save_pretrained(self, save_dir: str, use_safetensors: bool = False, **kwargs):
+    def save_pretrained(self, save_dir: str, use_safetensors: bool = False, safetensors_metadata: Optional[Dict[str, str]] = None, **kwargs):
         """alias of save_quantized"""
         logger.warning("you are using save_pretrained, which will re-direct to save_quantized.")
-        self.save_quantized(save_dir, use_safetensors)
+        self.save_quantized(save_dir, use_safetensors, safetensors_metadata)
 
     @classmethod
     def from_pretrained(

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -534,7 +534,10 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             # Format is required to enable Accelerate to load the metadata
             # otherwise it raises an OSError
             safetensors_metadata['format'] = "pt"
+
             # Store the quantization configuration as safetensors metadata
+            from auto_gptq import __version__
+            safetensors_metadata['auto_gptq_version'] = str(__version__)
             safetensors_metadata['gptq_bits'] = str(self.quantize_config.bits)
             safetensors_metadata['gptq_group_size'] = str(self.quantize_config.group_size)
             safetensors_metadata['gptq_desc_act'] = str(self.quantize_config.desc_act)


### PR DESCRIPTION
This PR adds some simple metadata to each saved `.safetensor` file, by passing a dict to `safe_save`.

It also allows the user to save any custom metadata, via new optional parameter in `.quantized()`: `safetensors_metadata`.

Reason one: it gets rid of this warning which users are regularly confused about:
```
2023-07-25 12:00:50 WARNING [accelerate.utils.modeling] The safetensors archive passed at /workspace/llama2-64g/gptq_model-4bit-64g.safetensors does not contain metadata. Make sure to save your model with the `save_pretrained` method. Defaulting to 'pt' metadata.
```

Reason two: it provides the ability to store some information that could be useful in future, if clients start to read them.

With this PR, the following values are automatically stored in the metadata of every quantized `.safetensor` file:
```python
safetensors_metadata['auto_gptq_version'] = str(__version__)
safetensors_metadata['gptq_bits'] = str(self.quantize_config.bits)
safetensors_metadata['gptq_group_size'] = str(self.quantize_config.group_size)
safetensors_metadata['gptq_desc_act'] = str(self.quantize_config.desc_act)
safetensors_metadata['gptq_damp_percent'] = str(self.quantize_config.damp_percent)
```

As well as the AutoGPTQ version number, I am also storing the GPTQ parameters. In future this could potentially be used instead of `quantize_config.json` by clients, if they wanted to.

Here is a demonstration of loading a .safetensor file saved with this PR, showing the default metadata that is now created by this PR:

Code to load metadata:
```python
from safetensors import safe_open

with safe_open("test-quant031/gptq_model-4bit-128g.safetensors", framework="pt") as f:
    metadata = f.metadata()
    weight_names = f.keys()

print(metadata) 
```
Output after this PR:
```
{'format': 'pt', 'gptq_group_size': '128', 'auto_gptq_version': '0.3.1', 'gptq_desc_act': 'False', 'gptq_bits': '4', 'gptq_damp_percent': '0.1'}
```

Additionally, the user can pass their own metadata dict through new parameter `safetensors_metadata` in `save_quantized()` and `push_to_hub()`.  This could be used by model creators to store information about their model.

For example, I would like to use custom metadata to store the following information about my quants:
- Dataset used during quant
- Sequence length used during quant (relevant now there are many models with support for >2K)
- Date of quantisation


Note: This PR is relative to https://github.com/PanQiWei/AutoGPTQ/pull/206 as it makes use of the `__version__` I added there.