### PR TITLE
Fix error raised when CUDA kernels are not installed

### DIFF
--- a/auto_gptq/nn_modules/qlinear/qlinear_cuda.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_cuda.py
@@ -14,8 +14,9 @@ try:
     _autogptq_cuda_available = True
 except ImportError:
     logger.warning('CUDA extension not installed.')
+    autogptq_cuda_256 = None
+    autogptq_cuda_64 = None
     _autogptq_cuda_available = False
-
 
 
 class QuantLinear(nn.Module):

--- a/auto_gptq/nn_modules/qlinear/qlinear_cuda_old.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_cuda_old.py
@@ -13,6 +13,8 @@ try:
     _autogptq_cuda_available = True
 except ImportError:
     logger.warning('CUDA extension not installed.')
+    autogptq_cuda_256 = None
+    autogptq_cuda_64 = None
     _autogptq_cuda_available = False
 
 


### PR DESCRIPTION
# What does this PR do

This pr fix the error raised when CUDA kernels are not installed by setting `autogptq_cuda_256` and `autogptq_cuda_64` to None when checking failed.