### PR TITLE
Fix build on non-CUDA machines after #206

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.version_info < python_min_version:
     print(f"You are using Python {platform.python_version()}. Python >={python_min_version_str} is required.")
     sys.exit(-1)
 
-if TORCH_AVAILABLE:
+if TORCH_AVAILABLE and torch.version.cuda != None:
     CUDA_VERSION = "".join(torch.version.cuda.split("."))
 else:
     CUDA_VERSION = "".join(os.environ.get("CUDA_VERSION", "").split("."))


### PR DESCRIPTION
This PR deploys a small fix to make sure the build succeeds on non-CUDA machines.

#206 introduced a slight change in the build that causes AutoGPTQ to fail on build on non-CUDA machines. However, there are parts of AutoGPTQ, like calculating perplexity, that does not require CUDA to run.

Resolves #211 