### PR TITLE
Fix revision used to load the quantization config

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -731,7 +731,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             raise TypeError(f"{config.model_type} isn't supported yet.")
 
         if quantize_config is None:
-            quantize_config = BaseQuantizeConfig.from_pretrained(model_name_or_path, **kwargs)
+            quantize_config = BaseQuantizeConfig.from_pretrained(model_name_or_path, **cached_file_kwargs, **kwargs)
         
         if model_basename is None:
             if quantize_config.model_file_base_name:


### PR DESCRIPTION
This is kind of critical @PanQiWei. The `revision` argument is ignored, which may lead to the wrong kernel being loaded.