### PR TITLE
[General Quant Linear] Register quant params of general quant linear for friendly post process.

### DIFF
--- a/auto_gptq/nn_modules/qlinear/__init__.py
+++ b/auto_gptq/nn_modules/qlinear/__init__.py
@@ -8,7 +8,6 @@ class GeneralQuantLinear(nn.Linear):
             out_features=quant_linear_module.outfeatures,
             bias=True
         )
-
         self.infeatures = quant_linear_module.infeatures
         self.outfeatures = quant_linear_module.outfeatures
         self.bits = quant_linear_module.bits
@@ -18,15 +17,15 @@ class GeneralQuantLinear(nn.Linear):
         self.weight.requires_grad = False
 
         self.weight.data = quant_linear_module.qweight
-        self.qweight = self.weight
+        self.register_buffer('qweight', quant_linear_module.qweight)
         self.bias.data = quant_linear_module.bias
 
         self.qweight.requires_grad = False
         self.bias.requires_grad = False
 
-        self.qzeros = quant_linear_module.qzeros
-        self.scales = quant_linear_module.scales
-        self.g_idx = quant_linear_module.g_idx
+        self.register_buffer('qzeros', quant_linear_module.qzeros)
+        self.register_buffer('scales', quant_linear_module.scales)
+        self.register_buffer('g_idx', quant_linear_module.g_idx)
 
         if hasattr(quant_linear_module, "wf"):
             self.wf = quant_linear_module.wf


### PR DESCRIPTION
Hi all, I have implemented support for  loading auto-gptq  pre-quantized checkpoints into MLC-LLM (based on the release 0.1.0 ). However this flow has encountered some issues with the `GeneralQuantLinear` in the release later than 0.2.0 has some issues of the load flow.

As from the compiler side, we load params with three different ways: named_buffers(), named_paramters(), state_dicts(), however, because the qweight, qzeros is not  registered in the GeneralQantLinear,  which means we cannot retrieve them using any of these methods.

This issue prevents us from fully utilizing the pre-quantized auto-gptq checkpoints in MLC-LLM. I believe addressing this issue will significantly enhance the functionality and flexibility of our model loading or post processing.

Thanks, and please CC @PanQiWei 