### PR TITLE
Patch exllama QuantLinear to avoid modifying the state dict

### DIFF
--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -202,7 +202,9 @@ def autogptq_post_init(model, use_act_order: bool):
                 }
             
             if not use_act_order:
-                submodule.g_idx = None
+                submodule._use_act_order = False
+            else:
+                submodule._use_act_order = True
 
             # Disable this heuristic for detecting act_order, but it could be used instead of the config.
             """

--- a/auto_gptq/nn_modules/qlinear/qlinear_exllama.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_exllama.py
@@ -92,12 +92,12 @@ class QuantLinear(nn.Module):
 
         self.width = self.qweight.shape[1]
 
-        # make_q4 segfaults if g_idx is not on cpu
+        # make_q4 segfaults if g_idx is not on cpu in the act-order case. In the non act-order case, None needs to be passed for g_idx.
         self.q4 = ext_make_q4(
             self.qweight,
             self.qzeros,
             self.scales,
-            self.g_idx.to("cpu") if self.g_idx is not None else self.g_idx,
+            self.g_idx.to("cpu") if self._use_act_order else None,
             self.qweight.device.index
         )
 


### PR DESCRIPTION
As per title, it would help if we can include this in a patch release before releasing on pypi, this would help make the integration with transformers smoother.

Avoids the unwanted warnings
```
Some weights of BloomForCausalLM were not initialized from the model checkpoint at /tmp/tmpgb5gyoq_ and are newly initialized: ['transformer.h.0.mlp.dense_4h_to_h.g_idx', 'transformer.h.16.self_attention.query_key_value.g_idx', 'transformer.h.23.mlp.dense_4h_to_h.g_idx'...]
```

cc @PanQiWei @SunMarc