### PR TITLE
Build wheels on ubuntu 20.04

### DIFF
--- a/.github/workflows/build_wheels_cuda.yml
+++ b/.github/workflows/build_wheels_cuda.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
         pyver: ["3.8", "3.9", "3.10", "3.11"]
         cuda: ["11.7", "11.8"]
     defaults:

--- a/.github/workflows/build_wheels_rocm.yml
+++ b/.github/workflows/build_wheels_rocm.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python: ["3.8", "3.9", "3.10", "3.11"]
         rocm: ["5.4.2"]  # , "5.5", "5.6"]
 


### PR DESCRIPTION
Currently, wheels are built on ubuntu 22.04 against libc 2.32, which breaks on ubuntu 20.04 systems that support only libc 2.31: `ImportError: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32'`