### PR TITLE
Fix python version for rocm build

### DIFF
--- a/.github/workflows/build_wheels_rocm.yml
+++ b/.github/workflows/build_wheels_rocm.yml
@@ -49,6 +49,10 @@ jobs:
           sudo rm -rf /usr/share/swift > /dev/null 2>&1
           df -h
 
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:

--- a/.github/workflows/build_wheels_rocm.yml
+++ b/.github/workflows/build_wheels_rocm.yml
@@ -67,6 +67,10 @@ jobs:
 
       - name: Set up environment
         run: |
+          echo "Using python:"
+          python --version
+          which python
+
           if [[ "${{ matrix.rocm }}" == "5.4.2" ]]; then
             export ROCM_DL_FILE=amdgpu-install_5.4.50402-1_all.deb
           elif [[ "${{ matrix.rocm }}" == "5.5" ]]; then
@@ -89,6 +93,10 @@ jobs:
 
       - name: Build wheels
         run: |
+          echo "Using python for build:"
+          python --version
+          which python
+
           ROCM_VERSION=${{ matrix.rocm }} python setup.py sdist bdist_wheel
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Revert https://github.com/PanQiWei/AutoGPTQ/pull/276. It appears that this action https://github.com/PanQiWei/AutoGPTQ/actions/runs/5950822354 used python 3.8 in all workflows for an unknown reason.

While https://github.com/PanQiWei/AutoGPTQ/actions/runs/5952031047 is successful.