### PR TITLE
Install skip qigen(windows)

### DIFF
--- a/auto_gptq/nn_modules/qlinear/qlinear_qigen.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_qigen.py
@@ -4,7 +4,6 @@ from torch import nn
 from tqdm import tqdm
 import gc
 
-import cQIGen as qinfer
 import math
 import numpy as np
 from gekko import GEKKO
@@ -12,6 +11,11 @@ from logging import getLogger
 
 logger = getLogger(__name__)
 
+try:
+    import cQIGen as qinfer
+except ImportError:
+    logger.error('cQIGen not installed.')
+    raise
 
 def mem_model(N, M, T, mu, tu, bits, l1, p, gs):
     m = GEKKO() # create GEKKO model

--- a/auto_gptq/utils/import_utils.py
+++ b/auto_gptq/utils/import_utils.py
@@ -25,6 +25,13 @@ try:
 except:
     EXLLAMA_KERNELS_AVAILABLE = False
 
+try:
+    import cQIGen as qinfer
+
+    QIGEN_AVAILABLE = True
+except:
+    QIGEN_AVAILABLE = False
+
 logger = getLogger(__name__)
 
 

--- a/setup.py
+++ b/setup.py
@@ -95,8 +95,8 @@ include_dirs = ["autogptq_cuda"]
 additional_setup_kwargs = dict()
 if BUILD_CUDA_EXT:
     from torch.utils import cpp_extension
-    
-    if platform != 'Windows':
+       
+    if platform.system() != 'Windows':
         p = int(subprocess.run("cat /proc/cpuinfo | grep cores | head -1", shell=True, check=True, text=True, stdout=subprocess.PIPE).stdout.split(" ")[2])
         subprocess.call(["python", "./autogptq_extension/qigen/generate.py", "--module", "--search", "--p", str(p)])
         
@@ -125,7 +125,7 @@ if BUILD_CUDA_EXT:
         )
     ]
     
-    if platform != 'Windows':
+    if platform.system() != 'Windows':
         extensions.append(
             cpp_extension.CppExtension(
                 "cQIGen",


### PR DESCRIPTION
qigen currently does not support windows. Therefore, we made it so that qigen is not installed on Windows.

Currently, I can make Windows generate qigen's backend.cpp, but pytorch fails to compile backend.cpp.