### PR TITLE
fix model type changed after calling .to() method

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -433,7 +433,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             return torch.device(device)
 
     def to(self, device: Union[str, torch.device]):
-        return self.model.to(device)
+        self.model.to(device)
+        return self
 
     def forward(self, *args, **kwargs):
         return self.model(*args, **kwargs)


### PR DESCRIPTION
The previous `BaseGPTQForCausalLM.to` returns internal `model` object which changed object type:
```python
    def to(self, device: Union[str, torch.device]):
        return self.model.to(device)
```

After fixing this bug, it always returns itself so object type will not be changed:
```python
    def to(self, device: Union[str, torch.device]):
        self.model.to(device)
        return self
```