### PR TITLE
Ignore unknown parameters in quantize_config.json

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -91,9 +91,17 @@ class BaseQuantizeConfig(PushToHubMixin):
                 _commit_hash=commit_hash,
             )
         
+        field_names = [field.name for field in fields(cls)]
         with open(resolved_config_file, "r", encoding="utf-8") as f:
-            return cls(**json.load(f))
-                
+            args_from_json = json.load(f)
+            filtered_args = {}
+            for key, val in args_from_json.items():
+                if key in field_names:
+                    filtered_args[key] = val
+                else:
+                    logger.warning(f"ignoring unknown parameter in {quantize_config_filename}: {key}.")
+            return cls(**filtered_args)
+
     def to_dict(self):
         return {
             "bits": self.bits,


### PR DESCRIPTION
The new version of AutoGPTQ added a new parameter into the `quantize_config.json` called `static_groups`. Now, if you have a model that was quantized with a new AutoGPTQ version and try to load it with an old AutoGPTQ version, you will get an error:
```
TypeError: BaseQuantizeConfig.__init__() got an unexpected keyword argument 'static_groups'
```

The newly created model is still compatible with the old AutoGPTQ version, but the extra parameter prevents the model from loading.

This PR makes it so all the unknown parameters in the `quantize_config.json` are ignored (and the warning is displayed). This ensures at least a minimal forward compatibility for the future AutoGPTQ versions.