### PR TITLE
Use `adapter_name` for `get_gptq_peft_model` with `train_mode=True`

### DIFF
--- a/auto_gptq/utils/peft_utils.py
+++ b/auto_gptq/utils/peft_utils.py
@@ -402,7 +402,7 @@ def get_gptq_peft_model(
     with hijack_peft_mappings():
         try:
             if train_mode:
-                peft_model = get_peft_model(model.model, peft_config)
+                peft_model = get_peft_model(model.model, peft_config, adapter_name=adapter_name)
             else:
                 peft_model = PeftModel.from_pretrained(model.model, model_id, adapter_name)
         except:


### PR DESCRIPTION
We have the following function to initialize PEFT adapters:
```python
def get_gptq_peft_model(
    model: BaseGPTQForCausalLM,
    peft_config: PeftConfig = None,
    model_id: str = None,
    adapter_name: str = "default",
    auto_find_all_linears: bool = True,
    train_mode: bool = False
):
```
However, by default it only uses the `adapter_name` parameter for the case when `train_mode=False`:
```python
    with hijack_peft_mappings():
        try:
            if train_mode:
                peft_model = get_peft_model(model.model, peft_config)
            else:
                peft_model = PeftModel.from_pretrained(model.model, model_id, adapter_name)
        except:
            raise NotImplementedError(
                f"{model.__class__.__name__} not support {peft_config.peft_type.value} peft type yet."
            )
```
So for instance if I called the function with the `chain-of-thoughts` adapter name - the transformers trainer checkpoint directory will still be like
```
- checkpoint-N
  - default
    - adapter_config,json
    - adapter_model.bin
```
instead of 
```
- checkpoint-N
  - chain-of-thoughts
    - adapter_config,json
    - adapter_model.bin
```
which I think maybe not be convenient (not to mention confusing because of ignoring parameters).