### PR TITLE
Allow using a model with basename `model`, use_safetensors defaults to True

### DIFF
--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -78,7 +78,7 @@ class AutoGPTQForCausalLM:
         use_cuda_fp16: bool = True,
         quantize_config: Optional[BaseQuantizeConfig] = None,
         model_basename: Optional[str] = None,
-        use_safetensors: bool = False,
+        use_safetensors: bool = True,
         trust_remote_code: bool = False,
         warmup_triton: bool = False,
         trainable: bool = False,

--- a/auto_gptq/nn_modules/triton_utils/custom_autotune.py
+++ b/auto_gptq/nn_modules/triton_utils/custom_autotune.py
@@ -71,8 +71,8 @@ class CustomizedTritonAutoTuner(triton.KernelInterface):
         try:
             # In testings using only 40 reps seems to be close enough and it appears to be what PyTorch uses
             # PyTorch also sets fast_flush to True, but I didn't see any speedup so I'll leave the default
-            return triton.testing.do_bench(kernel_call, percentiles=(0.5, 0.2, 0.8), rep=40)
-        except triton.compiler.OutOfResources:
+            return triton.testing.do_bench(kernel_call, quantiles=(0.5, 0.2, 0.8), rep=40)
+        except triton.OutOfResources:
             return (float('inf'), float('inf'), float('inf'))
 
     def run(self, *args, **kwargs):

--- a/examples/benchmark/generation_speed.py
+++ b/examples/benchmark/generation_speed.py
@@ -143,7 +143,7 @@ def load_model_tokenizer(
     quantize_config: Optional[str] = None,
     trust_remote_code: bool = False,
     use_triton: bool = False,
-    use_safetensors: bool = False,
+    use_safetensors: bool = True,
     use_fast_tokenizer: bool = False,
     inject_fused_attention: bool = True,
     inject_fused_mlp: bool = True,


### PR DESCRIPTION
As per title. Fix a few import bugs with recent Triton version as well.

Fixes https://github.com/PanQiWei/AutoGPTQ/issues/332