### PR TITLE
Fixed missing cstdint include

### DIFF
--- a/autogptq_extension/qigen/generate.py
+++ b/autogptq_extension/qigen/generate.py
@@ -94,7 +94,7 @@ def mem_model(N, M, T, mu, tu, bits, l1, p, gs, verbose=False):
 
 
 def macros():
-    return "#include<omp.h>\n#include<immintrin.h>\n#include<fstream>\n\n#define mymin(a,b) ((a)<(b)?(a):(b))\n#define mymax(a,b) ((a)>(b)?(a):(b))\n"
+    return "#include<omp.h>\n#include<cstdint>\n#include<immintrin.h>\n#include<fstream>\n\n#define mymin(a,b) ((a)<(b)?(a):(b))\n#define mymax(a,b) ((a)>(b)?(a):(b))\n"
 
 def print_parameters(bits, n, m, t, nb, mb, tb, mu, nu, tu, unroll, p, gs=-1):
     res = ""


### PR DESCRIPTION
While building auto-gptq for ROCm 5.6, I encountered the following error. 

```  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [60 lines of output]
      In file included from ./autogptq_extension/qigen/mmm.cpp:2:
      ./autogptq_extension/qigen/forward.h: In function ‘void pack_input(float*, float*)’:
      ./autogptq_extension/qigen/forward.h:172:3: error: ‘uint64_t’ was not declared in this scope
        172 |   uint64_t idx = 0;
            |   ^~~~~~~~
      ./autogptq_extension/qigen/forward.h:4:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
          3 | #include<fstream>
        +++ |+#include <cstdint>
          4 |
      ./autogptq_extension/qigen/forward.h:181:28: error: ‘idx’ was not declared in this scope
        181 |                          B[idx] = A[ii*M+jj];
            |                            ^~~
      ./autogptq_extension/qigen/forward.h: In function ‘void pack_qw_inner(int*, int*, int)’:
      ./autogptq_extension/qigen/forward.h:190:3: error: ‘uint64_t’ was not declared in this scope
        190 |   uint64_t idx = 0;
            |   ^~~~~~~~
      ./autogptq_extension/qigen/forward.h:190:3: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
      ./autogptq_extension/qigen/forward.h:199:32: error: ‘idx’ was not declared in this scope
        199 |                              B[idx] = A[ii*M+jj];
            |                                ^~~
      ./autogptq_extension/qigen/forward.h: In function ‘void pack_output(float*, float*)’:
      ./autogptq_extension/qigen/forward.h:211:3: error: ‘uint64_t’ was not declared in this scope
        211 |   uint64_t idx = 0;
            |   ^~~~~~~~
      ./autogptq_extension/qigen/forward.h:211:3: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
      ./autogptq_extension/qigen/forward.h:220:28: error: ‘idx’ was not declared in this scope
        220 |                          B[idx] = A[ii*M+jj];
            |                            ^~~
      Traceback (most recent call last):
        File "/AutoGPTQ/./autogptq_extension/qigen/generate.py", line 1475, in <module>
          gen_module_search(args.r, args.p, [2,3,4])
        File "/AutoGPTQ/./autogptq_extension/qigen/generate.py", line 1418, in gen_module_search
          gen_and_compile(n,m,t,n,mb,tb,1,mu,tu,p,u,bits=bits, gs=gs, module=True)
        File "/AutoGPTQ/./autogptq_extension/qigen/generate.py", line 799, in gen_and_compile
          subprocess.check_output(["g++", "-O3", "-o", "./autogptq_extension/qigen/mmm", "./autogptq_extension/qigen/mmm.cpp", "-mavx", "-mfma", "-mavx2", "-ftree-vectorize", "-fno-signaling-nans", "-fno-trapping-math", "-march=native", "-fopenmp"])
        File "/usr/lib/python3.11/subprocess.py", line 466, in check_output
          return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/lib/python3.11/subprocess.py", line 571, in run
          raise CalledProcessError(retcode, process.args,
      subprocess.CalledProcessError: Command '['g++', '-O3', '-o', './autogptq_extension/qigen/mmm', './autogptq_extension/qigen/mmm.cpp', '-mavx', '-mfma', '-mavx2', '-ftree-vectorize', '-fno-signaling-nans', '-fno-trapping-math', '-march=native', '-fopenmp']' returned non-zero exit status 1.
      Traceback (most recent call last):
        File "/AutoGPTQ/setup.py", line 103, in <module>
          subprocess.check_output(["python", "./autogptq_extension/qigen/generate.py", "--module", "--search", "--p", str(p)])
        File "/usr/lib/python3.11/subprocess.py", line 466, in check_output
          return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/lib/python3.11/subprocess.py", line 571, in run
          raise CalledProcessError(retcode, process.args,
      subprocess.CalledProcessError: Command '['python', './autogptq_extension/qigen/generate.py', '--module', '--search', '--p', '16']' returned non-zero exit status 1.
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "AutoGPTQ/setup.py", line 105, in <module>
          raise Exception(f"Generating QiGen kernels failed with the error shown above.")
      Exception: Generating QiGen kernels failed with the error shown above.
      Generating qigen kernels...
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

Adding the line `#include <cstdint>` to forward.h was not enough as this file gets modified by generate.py. So I had to to add `#include<cstdint>\n` to generate.py instead.

After this correction, I am able to build from source for ROCm 5.6 with the following command
`ROCM_VERSION=5.6 python -m pip install . --no-build-isolation`

