### PR TITLE
Fix CPU inference

### DIFF
--- a/auto_gptq/utils/exllama_utils.py
+++ b/auto_gptq/utils/exllama_utils.py
@@ -1,7 +1,6 @@
 import gc
 import torch
 
-from ..nn_modules.qlinear.qlinear_exllama import QuantLinear as ExllamaQuantLinear
 
 def exllama_set_max_input_length(model, max_input_length: int):
     """
@@ -13,6 +12,7 @@ def exllama_set_max_input_length(model, max_input_length: int):
 
     # The import is set here to avoid a global import. Arguably this is quite ugly, it would be better to have lazy loading.
     from exllama_kernels import prepare_buffers, cleanup_buffers_cuda
+    from ..nn_modules.qlinear.qlinear_exllama import QuantLinear as ExllamaQuantLinear
 
     if not model.quantize_config.desc_act:
         raise ValueError("The method exllama_set_max_input_length should be called only when using the exllama backend **with act-order**.")

--- a/auto_gptq/utils/peft_utils.py
+++ b/auto_gptq/utils/peft_utils.py
@@ -17,13 +17,29 @@ from ..modeling._base import BaseGPTQForCausalLM
 from ..nn_modules.qlinear import GeneralQuantLinear
 from ..nn_modules.qlinear.qlinear_cuda import QuantLinear as QuantLinearCuda
 from ..nn_modules.qlinear.qlinear_cuda_old import QuantLinear as QuantLinearCudaOld
-from ..nn_modules.qlinear.qlinear_exllama import QuantLinear as QuantLinearExllama
-from ..nn_modules.qlinear.qlinear_qigen import QuantLinear as QuantLinearQigen
-from ..nn_modules.qlinear.qlinear_triton import QuantLinear as QuantLinearTriton
 
 LinearLayer = Union[torch.nn.Linear, GeneralQuantLinear, QuantLinearCuda,
-                    QuantLinearCudaOld, QuantLinearExllama, QuantLinearQigen,
-                    QuantLinearTriton]
+                    QuantLinearCudaOld]
+from logging import getLogger
+logger = getLogger(__name__)
+try:
+    from ..nn_modules.qlinear.qlinear_exllama import QuantLinear as QuantLinearExllama
+    LinearLayer = Union[LinearLayer, QuantLinearExllama]
+except ImportError:
+    pass
+
+try:
+    from ..nn_modules.qlinear.qlinear_qigen import QuantLinear as QuantLinearQigen
+    LinearLayer = Union[LinearLayer, QuantLinearQigen]
+except ImportError:
+    pass
+
+try:
+    from ..nn_modules.qlinear.qlinear_cuda import QuantLinear as QuantLinearTriton
+    LinearLayer = Union[LinearLayer, QuantLinearTriton]
+except ImportError:
+    pass
+
 
 class GPTQLoraConfig(LoraConfig):
     injected_fused_attention: bool = False


### PR DESCRIPTION
This PR fixed a cuda library not found error when running inference on CPU or Intel XPU.

Before this PR, the following code would result an `ImportError: libcudart.so.12: cannot open shared object file: No such file or directory` on a machine without cuda, caused by importing exllama_kernels.

After this PR, the following code would return correct result both on CPU and Intel GPU.

(Thank you for the great library, by the way.)

```python
from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline, GPTQConfig
import torch
USE_XPU = True
if USE_XPU:
    import intel_extension_for_pytorch as ipex
model_name_or_path = "TheBloke/Llama-2-7B-GPTQ"
# To use a different branch, change revision
# For example: revision="main"
quantization_config = GPTQConfig(
    bits=4,
    use_exllama=False
)
model = AutoModelForCausalLM.from_pretrained(model_name_or_path,
                                             device_map="cpu",
                                             torch_dtype=torch.float if not USE_XPU else "auto",
                                             trust_remote_code=True,
                                             revision="main",
                                             quantization_config=quantization_config)
if USE_XPU:
    model = model.to("xpu")
print(model)

tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=True)

prompt = "Tell me about AI"
prompt_template=f'''{prompt}

'''

print("\n\n*** Generate:")

input_ids = tokenizer(prompt_template, return_tensors='pt').input_ids
if USE_XPU:
    input_ids = input_ids.to("xpu")
output = model.generate(inputs=input_ids, temperature=0.7, do_sample=True, top_p=0.95, top_k=40, max_new_tokens=4)
print(tokenizer.decode(output[0]))

'''

print("\n\n*** Generate:")

input_ids = tokenizer(prompt_template, return_tensors='pt').input_ids
output = model.generate(inputs=input_ids, temperature=0.7, do_sample=True, top_p=0.95, top_k=40, max_new_tokens=32)
print(tokenizer.decode(output[0]))
```