### PR TITLE
Add support for Yi models.

### DIFF
--- a/auto_gptq/modeling/__init__.py
+++ b/auto_gptq/modeling/__init__.py
@@ -14,3 +14,4 @@ from .baichuan import *
 from .internlm import *
 from .qwen import *
 from .mistral import *
+from .yi import *

--- a/auto_gptq/modeling/_const.py
+++ b/auto_gptq/modeling/_const.py
@@ -28,6 +28,7 @@ if compare_transformers_version("v4.33.0", op="ge"):
     SUPPORTED_MODELS.append("falcon")
 if compare_transformers_version("v4.34.0", op="ge"):
     SUPPORTED_MODELS.append("mistral")
+    SUPPORTED_MODELS.append("Yi")
 
 
 EXLLAMA_DEFAULT_MAX_INPUT_LENGTH = 2048

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -17,6 +17,7 @@ from .baichuan import BaiChuanGPTQForCausalLM
 from .internlm import InternLMGPTQForCausalLM
 from .qwen import QwenGPTQForCausalLM
 from .mistral import MistralGPTQForCausalLM
+from .yi import YiGPTQForCausalLM
 
 GPTQ_CAUSAL_LM_MODEL_MAP = {
     "bloom": BloomGPTQForCausalLM,
@@ -35,6 +36,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "internlm": InternLMGPTQForCausalLM,
     "qwen": QwenGPTQForCausalLM,
     "mistral": MistralGPTQForCausalLM,
+    "Yi": YiGPTQForCausalLM,
 }
 
 

--- a/auto_gptq/modeling/yi.py
+++ b/auto_gptq/modeling/yi.py
@@ -1,0 +1,31 @@
+from logging import getLogger
+
+from ._base import *
+from ..utils.import_utils import compare_transformers_version
+
+if compare_transformers_version("v4.28.0", op="ge"):
+    from ..nn_modules.fused_llama_attn import FusedLlamaAttentionForQuantizedModel
+    from ..nn_modules.fused_llama_mlp import FusedLlamaMLPForQuantizedModel
+else:
+    FusedLlamaAttentionForQuantizedModel = None
+    FusedLlamaMLPForQuantizedModel = None
+
+logger = getLogger(__name__)
+
+
+class YiGPTQForCausalLM(BaseGPTQForCausalLM):
+    layer_type = "YiDecoderLayer"
+    layers_block_name = "model.layers"
+    outside_layer_modules = ["model.embed_tokens", "model.norm"]
+    inside_layer_modules = [
+        ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.up_proj", "mlp.gate_proj"],
+        ["mlp.down_proj"]
+    ]
+
+    fused_attn_module_type = FusedLlamaAttentionForQuantizedModel
+    fused_mlp_module_type = FusedLlamaMLPForQuantizedModel
+
+
+__all__ = ["YiGPTQForCausalLM"]


### PR DESCRIPTION
Adds support for [01-ai/Yi](https://huggingface.co/01-ai/Yi-6B) models.

Quantization/inference tested with [01-ai/Yi-6B](https://huggingface.co/01-ai/Yi-6B)

Set `transformers=>4.34.0` even though the model is not supported by it yet, this was the req in their [repo](https://github.com/01-ai/Yi/blob/main/requirements.txt).

Use `trust_remote_code=True`

Since the model is actually very close to Llama, `FusedLlamaAttentionForQuantizedModel` and `FusedLlamaMLPForQuantizedModel` are added. I tested them and if they actually were used(no errors, same output) then they should be working. I'm not 100% since it seems triton isn't working and I had to make my own fix which seemed to work.(not in this PR. Added **kwargs to qlinear_triton init)

@TheBloke would be great if you could do a bit of a sanity check.