### PR TITLE
Add support for Xverse models.

### DIFF
--- a/auto_gptq/modeling/__init__.py
+++ b/auto_gptq/modeling/__init__.py
@@ -14,3 +14,4 @@ from .baichuan import *
 from .internlm import *
 from .qwen import *
 from .mistral import *
+from .xverse import *

--- a/auto_gptq/modeling/_const.py
+++ b/auto_gptq/modeling/_const.py
@@ -21,6 +21,7 @@ SUPPORTED_MODELS = [
     "baichuan",
     "internlm",
     "qwen",
+    "xverse",
 ]
 if compare_transformers_version("v4.28.0", op="ge"):
     SUPPORTED_MODELS.append("llama")

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -17,6 +17,7 @@ from .baichuan import BaiChuanGPTQForCausalLM
 from .internlm import InternLMGPTQForCausalLM
 from .qwen import QwenGPTQForCausalLM
 from .mistral import MistralGPTQForCausalLM
+from .xverse import XverseGPTQForCausalLM
 
 GPTQ_CAUSAL_LM_MODEL_MAP = {
     "bloom": BloomGPTQForCausalLM,
@@ -35,6 +36,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "internlm": InternLMGPTQForCausalLM,
     "qwen": QwenGPTQForCausalLM,
     "mistral": MistralGPTQForCausalLM,
+    "xverse": XverseGPTQForCausalLM,
 }
 
 

--- a/auto_gptq/modeling/xverse.py
+++ b/auto_gptq/modeling/xverse.py
@@ -1,0 +1,31 @@
+from logging import getLogger
+
+from ._base import *
+from ..utils.import_utils import compare_transformers_version
+
+if compare_transformers_version("v4.28.0", op="ge"):
+    from ..nn_modules.fused_llama_attn import FusedLlamaAttentionForQuantizedModel
+    from ..nn_modules.fused_llama_mlp import FusedLlamaMLPForQuantizedModel
+else:
+    FusedLlamaAttentionForQuantizedModel = None
+    FusedLlamaMLPForQuantizedModel = None
+
+logger = getLogger(__name__)
+
+
+class XverseGPTQForCausalLM(BaseGPTQForCausalLM):
+    layer_type = "XverseDecoderLayer"
+    layers_block_name = "model.layers"
+    outside_layer_modules = ["model.embed_tokens", "model.norm"]
+    inside_layer_modules = [
+        ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.up_proj", "mlp.gate_proj"],
+        ["mlp.down_proj"]
+    ]
+
+    fused_attn_module_type = FusedLlamaAttentionForQuantizedModel
+    fused_mlp_module_type = FusedLlamaMLPForQuantizedModel
+
+
+__all__ = ["XverseGPTQForCausalLM"]


### PR DESCRIPTION
Adds support for [xverse/XVERSE](https://huggingface.co/xverse/XVERSE-7B) models.

Quantization/inference tested with [xverse/XVERSE-7B](https://huggingface.co/xverse/XVERSE-7B)

Ver. 2 of the models are just further training, so they should work fine.

Very close to Llama, so `FusedLlamaAttentionForQuantizedModel` and `FusedLlamaMLPForQuantizedModel` are enabled.

`trust_remote_code=True` required.