### PR TITLE
Fix triton unexpected keyword

### DIFF
--- a/auto_gptq/nn_modules/qlinear/qlinear_triton.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_triton.py
@@ -39,7 +39,8 @@ class QuantLinear(nn.Module, TritonModuleMixin):
         infeatures,
         outfeatures,
         bias,
-        trainable=False
+        trainable=False,
+        **kwargs
     ):
         super().__init__()
         if bits not in [2, 4, 8]:


### PR DESCRIPTION
Fixes `TypeError: QuantLinear.__init__() got an unexpected keyword argument 'weight_dtype'` by adding **kwargs.

@fxmarty just a simple fix, triton was completely unusable.