### PR TITLE
Update _base.py - Remote (.bin) model load fix

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -826,11 +826,15 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                         true_model_basename = possible_model_basename
                         break
         else:  # remote
+            temp = None
             for ext in extensions:
                 for possible_model_basename in possible_model_basenames:
                     resolved_archive_file = cached_file(model_name_or_path, possible_model_basename + ext, **cached_file_kwargs)
+                    if resolved_archive_file is None:
+                        resolved_archive_file = temp
                     searched_files.append(possible_model_basename + ext)
                     if resolved_archive_file is not None:
+                        temp = resolved_archive_file
                         true_model_basename = possible_model_basename
                         break
         


### PR DESCRIPTION
Whats happening - 
```.bin``` Model is unable to load - FIleNotFound error.

When you load a model from huggingface remotely with ```use_safetensors = False```, there are two extensions to work with - ```.bin```, ```.pt```.  
Line 834, checks the cached model directory for the model base name with the above extensions in the same order as above.

Case - 1: If no model found with either extensions, the original code works as expected (throws error).
Case - 2: If models with both extensions found or if only ```.pt``` extension is found, the model with ```.pt``` extension loads. Although in the former case, the user has no liberty to choose between the two models.
Case - 3: If only ```.bin``` model exists. then it throws a FileNotFoundError as in the first case.


The fix - 
A simple fix with ```temp``` variable, which hold the latest found model in order to prevent the ```resolved_archive_file``` variable defaulting to ```None``` incase the  model with next search extension is not found.