### PR TITLE
Stop trying to convert a list to int in setup.py when trying to retrieve cores_info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ if BUILD_CUDA_EXT:
         print("Generating qigen kernels...")
         cores_info = subprocess.run("cat /proc/cpuinfo | grep cores | head -1", shell=True, check=True, text=True, stdout=subprocess.PIPE).stdout.split(" ")
         if (len(cores_info) == 3 and cores_info[1].startswith("cores")) or (len(cores_info) == 2):
-            p = int([cores_info[-1]])
+            p = int(cores_info[-1])
         else:
             p = os.cpu_count()
         try:


### PR DESCRIPTION
We had `p = int([cores_info[-1]])`, which will always throw an error as we cannot convert a list to int. This was likely a typo.