### PR TITLE
Add support for Mixtral models.

### DIFF
--- a/auto_gptq/modeling/__init__.py
+++ b/auto_gptq/modeling/__init__.py
@@ -16,3 +16,4 @@ from .qwen import *
 from .mistral import *
 from .yi import *
 from .xverse import *
+from .mixtral import *

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -888,7 +888,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 layers = find_layers(model)
                 ignore_layers = [cls.lm_head_name] + cls.outside_layer_modules
                 for name in list(layers.keys()):
-                    if any([name.startswith(ignore_layer) for ignore_layer in ignore_layers]) or layers[name].out_features % 32:
+                    if any([name.startswith(ignore_layer) for ignore_layer in ignore_layers]):
                         logger.info(f"{name} not been quantized, will be ignored when make_quant.")
                         del layers[name]
 

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -888,7 +888,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 layers = find_layers(model)
                 ignore_layers = [cls.lm_head_name] + cls.outside_layer_modules
                 for name in list(layers.keys()):
-                    if any([name.startswith(ignore_layer) for ignore_layer in ignore_layers]):
+                    if any([name.startswith(ignore_layer) for ignore_layer in ignore_layers]) or layers[name].out_features % 32:
                         logger.info(f"{name} not been quantized, will be ignored when make_quant.")
                         del layers[name]
 

--- a/auto_gptq/modeling/_const.py
+++ b/auto_gptq/modeling/_const.py
@@ -30,6 +30,8 @@ if compare_transformers_version("v4.33.0", op="ge"):
 if compare_transformers_version("v4.34.0", op="ge"):
     SUPPORTED_MODELS.append("mistral")
     SUPPORTED_MODELS.append("Yi")
+if compare_transformers_version("v4.36.0", op="ge"):
+    SUPPORTED_MODELS.append("mixtral")
 
 
 EXLLAMA_DEFAULT_MAX_INPUT_LENGTH = 2048

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -19,6 +19,7 @@ from .qwen import QwenGPTQForCausalLM
 from .mistral import MistralGPTQForCausalLM
 from .yi import YiGPTQForCausalLM
 from .xverse import XverseGPTQForCausalLM
+from .mixtral import MixtralGPTQForCausalLM
 
 GPTQ_CAUSAL_LM_MODEL_MAP = {
     "bloom": BloomGPTQForCausalLM,
@@ -39,6 +40,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "mistral": MistralGPTQForCausalLM,
     "Yi": YiGPTQForCausalLM,
     "xverse": XverseGPTQForCausalLM,
+    "mixtral": MixtralGPTQForCausalLM,
 }
 
 

--- a/auto_gptq/modeling/mixtral.py
+++ b/auto_gptq/modeling/mixtral.py
@@ -17,16 +17,6 @@ class MixtralGPTQForCausalLM(BaseGPTQForCausalLM):
             "block_sparse_moe.experts.5.w1",
             "block_sparse_moe.experts.6.w1",
             "block_sparse_moe.experts.7.w1",
-            "block_sparse_moe.experts.0.w2",
-            "block_sparse_moe.experts.1.w2",
-            "block_sparse_moe.experts.2.w2",
-            "block_sparse_moe.experts.3.w2",
-            "block_sparse_moe.experts.4.w2",
-            "block_sparse_moe.experts.5.w2",
-            "block_sparse_moe.experts.6.w2",
-            "block_sparse_moe.experts.7.w2",
-         ],
-        [
             "block_sparse_moe.experts.0.w3",
             "block_sparse_moe.experts.1.w3",
             "block_sparse_moe.experts.2.w3",
@@ -35,6 +25,16 @@ class MixtralGPTQForCausalLM(BaseGPTQForCausalLM):
             "block_sparse_moe.experts.5.w3",
             "block_sparse_moe.experts.6.w3",
             "block_sparse_moe.experts.7.w3",
+         ],
+        [
+            "block_sparse_moe.experts.0.w2",
+            "block_sparse_moe.experts.1.w2",
+            "block_sparse_moe.experts.2.w2",
+            "block_sparse_moe.experts.3.w2",
+            "block_sparse_moe.experts.4.w2",
+            "block_sparse_moe.experts.5.w2",
+            "block_sparse_moe.experts.6.w2",
+            "block_sparse_moe.experts.7.w2",
         ]
     ]
 

--- a/auto_gptq/modeling/mixtral.py
+++ b/auto_gptq/modeling/mixtral.py
@@ -8,14 +8,34 @@ class MixtralGPTQForCausalLM(BaseGPTQForCausalLM):
     inside_layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
         ["self_attn.o_proj"],
-        ["block_sparse_moe.experts.0.w1", "block_sparse_moe.experts.0.w2", "block_sparse_moe.experts.0.w3"],
-        ["block_sparse_moe.experts.1.w1", "block_sparse_moe.experts.1.w2", "block_sparse_moe.experts.1.w3"],
-        ["block_sparse_moe.experts.2.w1", "block_sparse_moe.experts.2.w2", "block_sparse_moe.experts.2.w3"],
-        ["block_sparse_moe.experts.3.w1", "block_sparse_moe.experts.3.w2", "block_sparse_moe.experts.3.w3"],
-        ["block_sparse_moe.experts.4.w1", "block_sparse_moe.experts.4.w2", "block_sparse_moe.experts.4.w3"],
-        ["block_sparse_moe.experts.5.w1", "block_sparse_moe.experts.5.w2", "block_sparse_moe.experts.5.w3"],
-        ["block_sparse_moe.experts.6.w1", "block_sparse_moe.experts.6.w2", "block_sparse_moe.experts.6.w3"],
-        ["block_sparse_moe.experts.7.w1", "block_sparse_moe.experts.7.w2", "block_sparse_moe.experts.7.w3"],
+        [
+            "block_sparse_moe.experts.0.w1",
+            "block_sparse_moe.experts.1.w1",
+            "block_sparse_moe.experts.2.w1",
+            "block_sparse_moe.experts.3.w1",
+            "block_sparse_moe.experts.4.w1",
+            "block_sparse_moe.experts.5.w1",
+            "block_sparse_moe.experts.6.w1",
+            "block_sparse_moe.experts.7.w1",
+            "block_sparse_moe.experts.0.w2",
+            "block_sparse_moe.experts.1.w2",
+            "block_sparse_moe.experts.2.w2",
+            "block_sparse_moe.experts.3.w2",
+            "block_sparse_moe.experts.4.w2",
+            "block_sparse_moe.experts.5.w2",
+            "block_sparse_moe.experts.6.w2",
+            "block_sparse_moe.experts.7.w2",
+         ],
+        [
+            "block_sparse_moe.experts.0.w3",
+            "block_sparse_moe.experts.1.w3",
+            "block_sparse_moe.experts.2.w3",
+            "block_sparse_moe.experts.3.w3",
+            "block_sparse_moe.experts.4.w3",
+            "block_sparse_moe.experts.5.w3",
+            "block_sparse_moe.experts.6.w3",
+            "block_sparse_moe.experts.7.w3",
+        ]
     ]
 
 

--- a/auto_gptq/modeling/mixtral.py
+++ b/auto_gptq/modeling/mixtral.py
@@ -1,0 +1,22 @@
+from ._base import *
+
+
+class MixtralGPTQForCausalLM(BaseGPTQForCausalLM):
+    layer_type = "MixtralDecoderLayer"
+    layers_block_name = "model.layers"
+    outside_layer_modules = ["model.embed_tokens", "model.norm"]
+    inside_layer_modules = [
+        ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
+        ["self_attn.o_proj"],
+        ["block_sparse_moe.experts.0.w1", "block_sparse_moe.experts.0.w2", "block_sparse_moe.experts.0.w3"],
+        ["block_sparse_moe.experts.1.w1", "block_sparse_moe.experts.1.w2", "block_sparse_moe.experts.1.w3"],
+        ["block_sparse_moe.experts.2.w1", "block_sparse_moe.experts.2.w2", "block_sparse_moe.experts.2.w3"],
+        ["block_sparse_moe.experts.3.w1", "block_sparse_moe.experts.3.w2", "block_sparse_moe.experts.3.w3"],
+        ["block_sparse_moe.experts.4.w1", "block_sparse_moe.experts.4.w2", "block_sparse_moe.experts.4.w3"],
+        ["block_sparse_moe.experts.5.w1", "block_sparse_moe.experts.5.w2", "block_sparse_moe.experts.5.w3"],
+        ["block_sparse_moe.experts.6.w1", "block_sparse_moe.experts.6.w2", "block_sparse_moe.experts.6.w3"],
+        ["block_sparse_moe.experts.7.w1", "block_sparse_moe.experts.7.w2", "block_sparse_moe.experts.7.w3"],
+    ]
+
+
+__all__ = ["MixtralGPTQForCausalLM"]

--- a/tests/test_q4.py
+++ b/tests/test_q4.py
@@ -665,3 +665,26 @@ class TestsQ4ExllamaV2(unittest.TestCase):
         self.assertTrue(inp["input_ids"].shape[1] > 2048)  # 2048 is the default max_input_length for LLama
         
         res = model_q.generate(**inp, num_beams=1, min_new_tokens=3, max_new_tokens=3)
+
+
+class TestsMixtral(unittest.TestCase):
+    def test_mixtral_generation(self):
+        prompt = "I am in Paris and"
+        device = torch.device("cuda:0")
+
+        # Reference generated with the cuda-old kernel
+        reference_output = '''<s> I am in Paris andpublishedющиеcs performancesension manual offset亡VIDEO Kel RepubliczwDrawlichen LondresPSungspfn CreahooEESlider laughselvesлександTrytpl recallслу Ор coldsubset########serdeacion providestrm thoughts président oktobermulticol../редβ themselvesterraряд conflictscommandMass diagonal選 ptrTY還 Havepliedument relate redu'''
+
+        model_id = "TheBlokeAI/Mixtral-tiny-GPTQ"
+        model_basename = "model"
+
+        model_q = AutoGPTQForCausalLM.from_quantized(model_id, use_safetensors=True, device="cuda:0", use_triton=False, inject_fused_attention=False, inject_fused_mlp=False, model_basename=model_basename)
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+        inp = tokenizer(prompt, return_tensors="pt").to(device)
+
+        res = model_q.generate(**inp, num_beams=1, min_new_tokens=60, max_new_tokens=60, do_sample=False)
+
+        predicted_text = tokenizer.decode(res[0])
+
+        self.assertEqual(predicted_text, reference_output)


### PR DESCRIPTION
Adds support for [mistralai/Mixtral-8x7B-v0.1](https://huggingface.co/mistralai/Mixtral-8x7B-v0.1)

Quantization/inference tested also with [hf-internal-testing/Mixtral-tiny](https://huggingface.co/hf-internal-testing/Mixtral-tiny)

Requires #479 for working inference.

`transformers>=4.36.0` + for transformers inference requires https://github.com/huggingface/transformers/pull/27956

Fixes #476