### PR TITLE
Add support for DeciLM models.

### DIFF
--- a/auto_gptq/modeling/__init__.py
+++ b/auto_gptq/modeling/__init__.py
@@ -16,3 +16,4 @@ from .qwen import *
 from .mistral import *
 from .yi import *
 from .xverse import *
+from .decilm import *

--- a/auto_gptq/modeling/_const.py
+++ b/auto_gptq/modeling/_const.py
@@ -22,6 +22,7 @@ SUPPORTED_MODELS = [
     "internlm",
     "qwen",
     "xverse",
+    "deci_lm",
 ]
 if compare_transformers_version("v4.28.0", op="ge"):
     SUPPORTED_MODELS.append("llama")

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -19,6 +19,7 @@ from .qwen import QwenGPTQForCausalLM
 from .mistral import MistralGPTQForCausalLM
 from .yi import YiGPTQForCausalLM
 from .xverse import XverseGPTQForCausalLM
+from .decilm import DeciLMGPTQForCausalLM
 
 GPTQ_CAUSAL_LM_MODEL_MAP = {
     "bloom": BloomGPTQForCausalLM,
@@ -39,6 +40,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "mistral": MistralGPTQForCausalLM,
     "Yi": YiGPTQForCausalLM,
     "xverse": XverseGPTQForCausalLM,
+    "deci_lm": DeciLMGPTQForCausalLM,
 }
 
 

--- a/auto_gptq/modeling/decilm.py
+++ b/auto_gptq/modeling/decilm.py
@@ -1,0 +1,31 @@
+from logging import getLogger
+
+from ._base import *
+from ..utils.import_utils import compare_transformers_version
+
+if compare_transformers_version("v4.28.0", op="ge"):
+    from ..nn_modules.fused_llama_attn import FusedLlamaAttentionForQuantizedModel
+    from ..nn_modules.fused_llama_mlp import FusedLlamaMLPForQuantizedModel
+else:
+    FusedLlamaAttentionForQuantizedModel = None
+    FusedLlamaMLPForQuantizedModel = None
+
+logger = getLogger(__name__)
+
+
+class DeciLMGPTQForCausalLM(BaseGPTQForCausalLM):
+    layer_type = "DeciLMDecoderLayer"
+    layers_block_name = "model.layers"
+    outside_layer_modules = ["model.embed_tokens", "model.norm"]
+    inside_layer_modules = [
+        ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.up_proj", "mlp.gate_proj"],
+        ["mlp.down_proj"]
+    ]
+
+    fused_attn_module_type = FusedLlamaAttentionForQuantizedModel
+    fused_mlp_module_type = FusedLlamaMLPForQuantizedModel
+
+
+__all__ = ["DeciLMGPTQForCausalLM"]


### PR DESCRIPTION
Adds support for [Deci/DeciLM-7B](https://huggingface.co/Deci/DeciLM-7B) models.

Quantization/Inference tested with the above model.

`trust_remote_code=True` required.

`FusedLlamaAttentionForQuantizedModel` and `FusedLlamaMLPForQuantizedModel` are enabled.