### PR TITLE
[Minor] peft bug fix:  HF peft version and tokenizer path in left scripts

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -78,6 +78,12 @@ Use `--help` flag to see detailed descriptions for more command arguments.
 ## PEFT
 > Commands in this chapter should be run under `peft` folder.
 
+Install `🤗 peft` in addition to AutoGPTQ:
+
+```sh
+    pip install "peft<0.7.0"
+```
+
 ### Lora
 `peft_lora_clm_instruction_tuning.py` script gives an example of instruction tuning gptq quantized model's lora adapter using tools in `auto_gptq.utils.peft_utils` and `🤗 peft` on alpaca dataset.
 

--- a/examples/peft/peft_adalora_clm_instruction_tuning.py
+++ b/examples/peft/peft_adalora_clm_instruction_tuning.py
@@ -47,7 +47,7 @@ peft_config = GPTQAdaLoraConfig(
     inference_mode=False,
 )
 
-tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=args.use_fast_tokenizer)
+tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path, use_fast=args.use_fast_tokenizer)
 if not tokenizer.pad_token_id:
     tokenizer.pad_token_id = tokenizer.eos_token_id
 

--- a/examples/peft/peft_adaption_prompt_clm_instruction_tuning.py
+++ b/examples/peft/peft_adaption_prompt_clm_instruction_tuning.py
@@ -41,7 +41,7 @@ peft_config = AdaptionPromptConfig(
     inference_mode=False,
 )
 
-tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=args.use_fast_tokenizer)
+tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path, use_fast=args.use_fast_tokenizer)
 if not tokenizer.pad_token_id:
     tokenizer.pad_token_id = tokenizer.eos_token_id
 

--- a/examples/peft/peft_lora_clm_instruction_tuning.py
+++ b/examples/peft/peft_lora_clm_instruction_tuning.py
@@ -41,7 +41,7 @@ peft_config = GPTQLoraConfig(
     inference_mode=False,
 )
 
-tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=args.use_fast_tokenizer)
+tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path, use_fast=args.use_fast_tokenizer)
 if not tokenizer.pad_token_id:
     tokenizer.pad_token_id = tokenizer.eos_token_id
 


### PR DESCRIPTION
1. HF peft `LoraLayer` init API have changed v0.7.0. With HF peft > 0.7.0, I get the error in the attached error while trying to run examples/peft/peft_lora_clm_instruction_tuning.py:
```
    return GPTQLoraLinear(
  File "/workspace/AutoGPTQ/auto_gptq/utils/peft_utils.py", line 61, in __init__
    torch.nn.Linear.__init__(self, in_features, out_features)
  File "/home/akuriparambi/anaconda3/envs/agptq/lib/python3.9/site-packages/torch/nn/modules/linear.py", line 96, in __init__
    self.weight = Parameter(torch.empty((out_features, in_features), **factory_kwargs))
  File "/home/akuriparambi/anaconda3/envs/agptq/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1712, in __setattr__
    self.register_parameter(name, value)
  File "/home/akuriparambi/anaconda3/envs/agptq/lib/python3.9/site-packages/torch/nn/modules/module.py", line 577, in register_parameter
    elif hasattr(self, name) and name not in self._parameters:
  File "/home/akuriparambi/anaconda3/envs/agptq/lib/python3.9/site-packages/peft/tuners/tuners_utils.py", line 358, in weight
    weight = base_layer.weight
  File "/home/akuriparambi/anaconda3/envs/agptq/lib/python3.9/site-packages/peft/tuners/tuners_utils.py", line 358, in weight
    weight = base_layer.weight
  File "/home/akuriparambi/anaconda3/envs/agptq/lib/python3.9/site-packages/peft/tuners/tuners_utils.py", line 358, in weight
    weight = base_layer.weight
  [Previous line repeated 975 more times]
  File "/home/akuriparambi/anaconda3/envs/agptq/lib/python3.9/site-packages/peft/tuners/tuners_utils.py", line 352, in weight
    base_layer = self.get_base_layer()
  File "/home/akuriparambi/anaconda3/envs/agptq/lib/python3.9/site-packages/peft/tuners/tuners_utils.py", line 341, in get_base_layer
    while hasattr(base_layer, "base_layer"):
  File "/home/akuriparambi/anaconda3/envs/agptq/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1695, in __getattr__
    raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
RecursionError: maximum recursion depth exceeded while calling a Python object
```

I have added the left installation instructions to the examples `README`.

2. A minor bug in `examples/peft` - `tokenizer_name_or_path` is used to initialize `AutoTokenizer` instead of `model_name_or_path`:
`model_name_or_path` points to the GPTQ saved model which might not have the tokenizer saved. `tokenizer_name_or_path` should be used instead.