### PR TITLE
Format logging output in a form of a table

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -66,7 +66,7 @@ from ._utils import (
 
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
-formatter = logging.Formatter("%(levelname)s - %(message)s")
+formatter = logging.Formatter("%(asctime)s ｜ %(levelname)s ｜ %(name)-27s ｜ %(message)s", datefmt="%Y-%m-%d ｜ %H:%M:%S")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -407,7 +407,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             inside_layer_modules = [sum(inside_layer_modules, [])]
         quantizers = {}
         for i in range(len(layers)):
-            logger.info(f"Start quantizing layer {i + 1}/{len(layers)}")
+            logger.info(f"--- Start quantizing layer {i + 1}/{len(layers)} ---")
             layer = layers[i]
             force_layer_back_to_cpu = False
             if get_device(layer) == CPU:


### PR DESCRIPTION
Hello there 👋 

Thanks for repo!
Decided to add my little contribution.

With the current main the logging output during quantization is such:
```text
INFO - Start quantizing layer 1/6
INFO - Quantizing attn.attn in layer 1/6...
INFO - Quantizing attn.proj in layer 1/6...
INFO - Quantizing mlp.fc in layer 1/6...
INFO - Quantizing mlp.proj in layer 1/6...
INFO - Start quantizing layer 2/6
INFO - Quantizing attn.attn in layer 2/6...
INFO - Quantizing attn.proj in layer 2/6...
INFO - Quantizing mlp.fc in layer 2/6...
INFO - Quantizing mlp.proj in layer 2/6...
INFO - Start quantizing layer 3/6
INFO - Quantizing attn.attn in layer 3/6...
INFO - Quantizing attn.proj in layer 3/6...
INFO - Quantizing mlp.fc in layer 3/6...
INFO - Quantizing mlp.proj in layer 3/6...
INFO - Start quantizing layer 4/6
INFO - Quantizing attn.attn in layer 4/6...
INFO - Quantizing attn.proj in layer 4/6...
INFO - Quantizing mlp.fc in layer 4/6...
INFO - Quantizing mlp.proj in layer 4/6...
INFO - Start quantizing layer 5/6
INFO - Quantizing attn.attn in layer 5/6...
INFO - Quantizing attn.proj in layer 5/6...
INFO - Quantizing mlp.fc in layer 5/6...
INFO - Quantizing mlp.proj in layer 5/6...
INFO - Start quantizing layer 6/6
INFO - Quantizing attn.attn in layer 6/6...
INFO - Quantizing attn.proj in layer 6/6...
INFO - Quantizing mlp.fc in layer 6/6...
INFO - Quantizing mlp.proj in layer 6/6...
```

and with the PR:
```text
2024-02-28 ｜ 11:33:03 ｜ INFO ｜ auto_gptq.modeling._base    ｜ --- Start quantizing layer 1/6 ---
2024-02-28 ｜ 11:33:03 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.attn in layer 1/6...
2024-02-28 ｜ 11:33:04 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.proj in layer 1/6...
2024-02-28 ｜ 11:33:04 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.fc in layer 1/6...
2024-02-28 ｜ 11:33:04 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.proj in layer 1/6...
2024-02-28 ｜ 11:33:04 ｜ INFO ｜ auto_gptq.modeling._base    ｜ --- Start quantizing layer 2/6 ---
2024-02-28 ｜ 11:33:04 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.attn in layer 2/6...
2024-02-28 ｜ 11:33:04 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.proj in layer 2/6...
2024-02-28 ｜ 11:33:04 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.fc in layer 2/6...
2024-02-28 ｜ 11:33:04 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.proj in layer 2/6...
2024-02-28 ｜ 11:33:05 ｜ INFO ｜ auto_gptq.modeling._base    ｜ --- Start quantizing layer 3/6 ---
2024-02-28 ｜ 11:33:05 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.attn in layer 3/6...
2024-02-28 ｜ 11:33:05 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.proj in layer 3/6...
2024-02-28 ｜ 11:33:05 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.fc in layer 3/6...
2024-02-28 ｜ 11:33:05 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.proj in layer 3/6...
2024-02-28 ｜ 11:33:05 ｜ INFO ｜ auto_gptq.modeling._base    ｜ --- Start quantizing layer 4/6 ---
2024-02-28 ｜ 11:33:05 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.attn in layer 4/6...
2024-02-28 ｜ 11:33:05 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.proj in layer 4/6...
2024-02-28 ｜ 11:33:05 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.fc in layer 4/6...
2024-02-28 ｜ 11:33:05 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.proj in layer 4/6...
2024-02-28 ｜ 11:33:06 ｜ INFO ｜ auto_gptq.modeling._base    ｜ --- Start quantizing layer 5/6 ---
2024-02-28 ｜ 11:33:06 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.attn in layer 5/6...
2024-02-28 ｜ 11:33:06 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.proj in layer 5/6...
2024-02-28 ｜ 11:33:06 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.fc in layer 5/6...
2024-02-28 ｜ 11:33:06 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.proj in layer 5/6...
2024-02-28 ｜ 11:33:06 ｜ INFO ｜ auto_gptq.modeling._base    ｜ --- Start quantizing layer 6/6 ---
2024-02-28 ｜ 11:33:06 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.attn in layer 6/6...
2024-02-28 ｜ 11:33:06 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing attn.proj in layer 6/6...
2024-02-28 ｜ 11:33:06 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.fc in layer 6/6...
2024-02-28 ｜ 11:33:06 ｜ INFO ｜ auto_gptq.modeling._base    ｜ Quantizing mlp.proj in layer 6/6...
```

Of course it's a matter of personal preference, but I think that the table looks more tidy.
Plus I visually separated each layer with `---` signs.